### PR TITLE
Implement repository pattern for data access layers

### DIFF
--- a/BlazorBlog.Data/Models/BlogPostDto.cs
+++ b/BlazorBlog.Data/Models/BlogPostDto.cs
@@ -1,4 +1,6 @@
-﻿namespace BlazorBlog.Services.Models
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace BlazorBlog.Data.Models
 {
     public class BlogPostDto
     {

--- a/BlazorBlog.Data/Models/DetailPageModel.cs
+++ b/BlazorBlog.Data/Models/DetailPageModel.cs
@@ -1,4 +1,6 @@
-﻿namespace BlazorBlog.Services.Models;
+﻿using BlazorBlog.Data.Entities;
+
+namespace BlazorBlog.Data.Models;
 
 public record DetailPageModel(BlogPost BlogPost, BlogPost[] RelatedPosts)
 {

--- a/BlazorBlog.Data/Models/PageResult.cs
+++ b/BlazorBlog.Data/Models/PageResult.cs
@@ -1,4 +1,4 @@
-﻿namespace BlazorBlog.Services.Models
+﻿namespace BlazorBlog.Data.Models
 {
     public record PageResult<TResult>(TResult[] Records, int TotalCount);
 }

--- a/BlazorBlog.Repository/BlazorBlog.Repository.csproj
+++ b/BlazorBlog.Repository/BlazorBlog.Repository.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\BlazorBlog.Repository\BlazorBlog.Repository.csproj" />
+    <ProjectReference Include="..\BlazorBlog.Data\BlazorBlog.Data.csproj" />
   </ItemGroup>
 
 </Project>

--- a/BlazorBlog.Repository/BlogPostRepository.cs
+++ b/BlazorBlog.Repository/BlogPostRepository.cs
@@ -1,0 +1,222 @@
+﻿namespace BlazorBlog.Repository
+{
+    using Data.Entities;
+    using Data.Models;
+    using Data;
+    using Contracts;
+    using Microsoft.EntityFrameworkCore;
+
+    using System;
+    using System.Threading.Tasks;
+
+    public class BlogPostRepository : IBlogPostRepository
+    {
+        private readonly IDbContextFactory<ApplicationDbContext> _contextFactory;
+
+        public BlogPostRepository(IDbContextFactory<ApplicationDbContext> contextFactory)
+        {
+            _contextFactory = contextFactory;
+        }
+
+        public async Task<PageResult<BlogPost>> GetBlogPostsAsync(int startIndex, int pageSize)
+        {
+            await using var context = _contextFactory.CreateDbContext();
+            var query = context.BlogPosts.AsNoTracking();
+
+            var count = await query.CountAsync();
+            var results = await query.Include(b => b.Category)
+                .OrderByDescending(b => b.CreatedAt)
+                .Skip(startIndex)
+                .Take(pageSize)
+                .ToArrayAsync();
+
+            return new PageResult<BlogPost>(results, count);
+        }
+
+        public async Task<BlogPost?> GetBlogPostByIdAsync(int id)
+        {
+            await using var context = await _contextFactory.CreateDbContextAsync();
+            return await context.BlogPosts
+                .AsNoTracking()
+                .Include(b => b.Category)
+                .FirstOrDefaultAsync(b => b.Id == id);
+        }
+
+        public async Task<BlogPost> SaveBlogPostAsync(BlogPost blogPost, string userId)
+        {
+            await using var context = await _contextFactory.CreateDbContextAsync();
+            if (blogPost.Id == 0)
+            {
+                var isTitleExist = await context.BlogPosts
+                    .AsNoTracking()
+                    .AnyAsync(b => b.Title == blogPost.Title);
+
+                if (isTitleExist)
+                {
+                    throw new InvalidOperationException($"A blog post with this same title already exists.");
+                }
+
+                blogPost.Slug = GenerateSlug(blogPost.Title);
+                blogPost.CreatedAt = DateTime.UtcNow;
+                blogPost.UserId = userId;
+                blogPost.PublishedAt = blogPost.IsPublished ? DateTime.UtcNow : null;
+
+                await context.BlogPosts.AddAsync(blogPost);
+            }
+            else
+            {
+                var existingBlogPost = await context.BlogPosts.FindAsync(blogPost.Id);
+                if (existingBlogPost == null)
+                {
+                    throw new InvalidOperationException($"Blog post not found.");
+                }
+
+                // Обновяване на съществуващия пост
+                existingBlogPost.Title = blogPost.Title;
+                existingBlogPost.Image = blogPost.Image;
+                existingBlogPost.Introduction = blogPost.Introduction;
+                existingBlogPost.Content = blogPost.Content;
+                existingBlogPost.CategoryId = blogPost.CategoryId;
+                existingBlogPost.IsFeatured = blogPost.IsFeatured;
+                existingBlogPost.IsPublished = blogPost.IsPublished;
+            
+
+                if (blogPost.IsPublished && existingBlogPost.PublishedAt == null)
+                {
+                    existingBlogPost.PublishedAt = DateTime.UtcNow;
+                }
+            }
+
+            await context.SaveChangesAsync();
+            return blogPost;
+        }
+
+        public async Task<bool> DeleteBlogPostAsync(int id)
+        {
+            await using var context = await _contextFactory.CreateDbContextAsync();
+            var blogPost = await context.BlogPosts.FindAsync(id);
+            if (blogPost == null) return false;
+
+            context.BlogPosts.Remove(blogPost);
+            await context.SaveChangesAsync();
+            return true;
+        }
+
+        private string GenerateSlug(string title)
+        {
+            return title.ToLower().Replace(" ", "-");
+        }
+
+        public async Task<BlogPost[]> GetBlogPostsAsync(int pageIndex, int pageSize, int categoryId)
+        {
+            await using var context = await _contextFactory.CreateDbContextAsync();
+            IQueryable<BlogPost> query = context.BlogPosts
+                .AsNoTracking()
+                .Include(p => p.Category)
+                .Include(p => p.User)
+                .Where(p => p.IsPublished);
+
+            if (categoryId > 0)
+            {
+                query = query.Where(p => p.CategoryId == categoryId);
+            }
+
+            var posts = await query
+                .OrderByDescending(p => p.PublishedAt)
+                .Skip(pageIndex * pageSize)
+                .Take(pageSize)
+                .ToArrayAsync();
+
+            return posts;
+        }
+
+        public async Task<BlogPost[]> GetFeaturedBlogPostsAsync(int count, int categoryId = 0)
+        {
+            await using var context = await _contextFactory.CreateDbContextAsync();
+            var query = context.BlogPosts
+                .AsNoTracking()
+                .Include(p => p.Category)
+                .Include(p => p.User)
+                .Where(p => p.IsPublished && p.IsFeatured);
+
+            if (categoryId > 0)
+            {
+                query = query.Where(p => p.CategoryId == categoryId);
+            }
+
+            var records = await query
+                .OrderBy(_ => Guid.NewGuid())
+                .Take(count)
+                .ToArrayAsync();
+
+            return records;
+        }
+
+
+        public async Task<BlogPost[]> GetPopularBlogPostsAsync(int count, int categoryId = 0)
+        {
+            await using var context = _contextFactory.CreateDbContext();
+            var query = context.BlogPosts
+                .AsNoTracking()
+                .Include(p => p.Category)
+                .Include(p => p.User)
+                .Where(p => p.IsPublished);
+
+            if (categoryId > 0)
+            {
+                query = query.Where(p => p.CategoryId == categoryId);
+            }
+
+            return await query
+                .OrderByDescending(p => p.ViewCount)
+                .Take(count)
+                .ToArrayAsync();
+        }
+
+        public async Task<BlogPost[]> GetRecentBlogPostsAsync(int count, int categoryId = 0)
+        {
+            await using var context = _contextFactory.CreateDbContext();
+            var query = context.BlogPosts
+                .AsNoTracking()
+                .Include(p => p.Category)
+                .Include(p => p.User)
+                .Where(p => p.IsPublished);
+
+            if (categoryId > 0)
+            {
+                query = query.Where(p => p.CategoryId == categoryId);
+            }
+
+            return await query
+                .OrderByDescending(p => p.PublishedAt)
+                .Take(count)
+                .ToArrayAsync();
+        }
+
+        public async Task<DetailPageModel> GetBlogPostBySlugAsync(string slug)
+        {
+            await using var context = _contextFactory.CreateDbContext();
+            var blogPost = await context.BlogPosts
+                .AsNoTracking()
+                .Include(p => p.Category)
+                .Include(p => p.User)
+                .FirstOrDefaultAsync(p => p.Slug == slug && p.IsPublished);
+
+            if (blogPost == null)
+            {
+                return DetailPageModel.Empty();
+            }
+
+            var relatedPosts = await context.BlogPosts
+                .AsNoTracking()
+                .Include(p => p.Category)
+                .Include(p => p.User)
+                .Where(p => p.CategoryId == blogPost.CategoryId && p.Id != blogPost.Id && p.IsPublished)
+                .OrderBy(_ => Guid.NewGuid())
+                .Take(4)
+                .ToArrayAsync();
+
+            return new DetailPageModel(blogPost, relatedPosts);
+        }
+    }
+}

--- a/BlazorBlog.Repository/CategoryRepository.cs
+++ b/BlazorBlog.Repository/CategoryRepository.cs
@@ -1,0 +1,68 @@
+﻿namespace BlazorBlog.Repository
+{
+    using Common;
+    using Data.Entities;
+    using Data;
+    using Contracts;
+    using Microsoft.EntityFrameworkCore;
+
+    public class CategoryRepository : ICategoryRepository
+    {
+        private readonly IDbContextFactory<ApplicationDbContext> _contextFactory;
+
+        public CategoryRepository(IDbContextFactory<ApplicationDbContext> contextFactory)
+        {
+            _contextFactory = contextFactory;
+        }
+
+        public async Task<Category[]> GetCategoriesAsync()
+        {
+            await using var context = await _contextFactory.CreateDbContextAsync();
+            return await context.Categories.AsNoTracking().ToArrayAsync();
+        }
+
+        public async Task<Category> SaveCategoryAsync(Category category)
+        {
+            await using var context = await _contextFactory.CreateDbContextAsync();
+            if (category.Id == 0)
+            {
+                var existingCategory = await context.Categories.AsNoTracking()
+                    .AnyAsync(c => c.Name == category.Name);
+                if (existingCategory)
+                {
+                    throw new InvalidOperationException($"Category with the name {category.Name} already exists.");
+                }
+                category.Slug = category.Name.ToSlug();
+                await context.Categories.AddAsync(category);
+            }
+            else
+            {
+                var dbCategory = await context.Categories.FindAsync(category.Id);
+                if (dbCategory != null)
+                {
+                    dbCategory.Name = category.Name;
+                    dbCategory.Slug = category.Name.ToSlug();
+                    dbCategory.ShowOnNavBar = category.ShowOnNavBar;
+                }
+            }
+            await context.SaveChangesAsync();
+            return category;
+        }
+
+        public async Task<bool> DeleteCategoryAsync(int id)
+        {
+            await using var context = await _contextFactory.CreateDbContextAsync();
+            var category = await context.Categories.FindAsync(id);
+            if (category == null) return false;
+            context.Categories.Remove(category);
+            await context.SaveChangesAsync();
+            return true;
+        }
+
+        public async Task<Category?> GetCategoryBySlugAsync(string slug)
+        {
+            await using var context = await _contextFactory.CreateDbContextAsync();
+            return await context.Categories.AsNoTracking().FirstOrDefaultAsync(c => c.Slug == slug);
+        }
+    }
+}

--- a/BlazorBlog.Repository/Common/AppConstants.cs
+++ b/BlazorBlog.Repository/Common/AppConstants.cs
@@ -1,0 +1,10 @@
+﻿namespace BlazorBlog.Repository.Common
+{
+    public static class AppConstants
+    {
+        public static class ClaimNames
+        {
+            public const string FullName = "FullName";
+        }
+    }
+}

--- a/BlazorBlog.Repository/Common/Extensions.cs
+++ b/BlazorBlog.Repository/Common/Extensions.cs
@@ -1,0 +1,32 @@
+﻿namespace BlazorBlog.Repository.Common
+{
+
+    using System.Security.Claims;
+    using System.Text.RegularExpressions;
+
+    public static partial class Extensions
+    {
+        public static string GetUserName(this ClaimsPrincipal principal) =>
+            principal.FindFirstValue(AppConstants.ClaimNames.FullName)!;
+
+        public static string GetUserId(this ClaimsPrincipal principal) =>
+            principal.FindFirstValue(ClaimTypes.NameIdentifier)!;
+
+        public static string ToSlug(this string text)
+        {
+            text = text.ToLowerInvariant()
+                .Replace(' ', '-');
+
+            text = SlugRegex().Replace(text, "-");
+
+            return text.Replace("--", "-")
+                .Trim('-');
+        }
+
+        [GeneratedRegex(@"[^0-9a-z_]")]
+        private static partial Regex SlugRegex();
+
+        public static string ToDisplayDate(this DateTime? date) =>
+			date?.ToString("MMM dd") ?? string.Empty;
+    }
+}

--- a/BlazorBlog.Repository/Common/Utils.cs
+++ b/BlazorBlog.Repository/Common/Utils.cs
@@ -1,0 +1,7 @@
+﻿namespace BlazorBlog.Repository.Common
+{
+    public static class Utils
+    {
+        public static string GetPageTitle(string title) => $"{title} | Blazor Blog";
+    }
+}

--- a/BlazorBlog.Repository/Contracts/IBlogPostRepository.cs
+++ b/BlazorBlog.Repository/Contracts/IBlogPostRepository.cs
@@ -1,9 +1,18 @@
-﻿namespace BlazorBlog.Services.Contracts
+﻿namespace BlazorBlog.Repository.Contracts
 {
     using Data.Models;
+    using Data.Entities;
 
-    public interface IBlogPostService
+    public interface IBlogPostRepository
     {
+        Task<PageResult<BlogPost>> GetBlogPostsAsync(int startIndex, int pageSize);
+
+        Task<BlogPost?> GetBlogPostByIdAsync(int id);
+
+        Task<BlogPost> SaveBlogPostAsync(BlogPost blogPost, string userId);
+
+        Task<bool> DeleteBlogPostAsync(int id);
+
         Task<BlogPost[]> GetFeaturedBlogPostsAsync(int count, int categoryId = 0);
 
         Task<BlogPost[]> GetPopularBlogPostsAsync(int count, int categoryId = 0);

--- a/BlazorBlog.Repository/Contracts/ICategoryRepository.cs
+++ b/BlazorBlog.Repository/Contracts/ICategoryRepository.cs
@@ -1,0 +1,16 @@
+﻿namespace BlazorBlog.Repository.Contracts
+{
+    using BlazorBlog.Data.Entities;
+
+    public interface ICategoryRepository
+    {
+        Task<Category[]> GetCategoriesAsync();
+
+        Task<Category> SaveCategoryAsync(Category category);
+
+        Task<bool> DeleteCategoryAsync(int id);
+
+        Task<Category?> GetCategoryBySlugAsync(string slug);
+    }
+
+}

--- a/BlazorBlog.Repository/Contracts/ISubscriberRepository.cs
+++ b/BlazorBlog.Repository/Contracts/ISubscriberRepository.cs
@@ -1,0 +1,11 @@
+﻿namespace BlazorBlog.Repository.Contracts
+{
+    using Data.Entities;
+    using Data.Models;
+
+    public interface ISubscriberRepository
+    {
+        Task<string?> AddSubscriberAsync(Subscriber subscriber);
+        Task<PageResult<Subscriber>> GetSubscribersAsync(int startIndex, int pageSize);
+    }
+}

--- a/BlazorBlog.Repository/SubscriberRepository.cs
+++ b/BlazorBlog.Repository/SubscriberRepository.cs
@@ -1,0 +1,53 @@
+﻿namespace BlazorBlog.Repository
+{
+    using Data.Entities;
+    using Data.Models;
+    using Data;
+    using Contracts;
+    using Microsoft.EntityFrameworkCore;
+
+    public class SubscriberRepository : ISubscriberRepository
+    {
+        private readonly IDbContextFactory<ApplicationDbContext> _contextFactory;
+
+        public SubscriberRepository(IDbContextFactory<ApplicationDbContext> contextFactory)
+        {
+            _contextFactory = contextFactory;
+        }
+
+        public async Task<string?> AddSubscriberAsync(Subscriber subscriber)
+        {
+            await using var context = await _contextFactory.CreateDbContextAsync();
+            var existingSubscriber = await context.Subscribers
+                .FirstOrDefaultAsync(s => s.Email == subscriber.Email);
+
+            if (existingSubscriber != null)
+            {
+                return "You are already subscribed.";
+            }
+
+            subscriber.SubscribedOn = DateTime.UtcNow;
+
+            await context.Subscribers.AddAsync(subscriber);
+            await context.SaveChangesAsync();
+
+            return null;
+        }
+
+        public async Task<PageResult<Subscriber>> GetSubscribersAsync(int startIndex, int pageSize)
+        {
+            await using var context = await _contextFactory.CreateDbContextAsync();
+            var totalRecords = await context.Subscribers.CountAsync();
+
+            var records = await context.Subscribers
+                .AsNoTracking()
+                .OrderByDescending(s => s.SubscribedOn)
+                .Skip(startIndex)
+                .Take(pageSize)
+                .ToArrayAsync();
+
+            return new PageResult<Subscriber>(records, totalRecords);
+        }
+    }
+
+}

--- a/BlazorBlog.Services/BlogPostAdminService.cs
+++ b/BlazorBlog.Services/BlogPostAdminService.cs
@@ -1,145 +1,35 @@
 ﻿namespace BlazorBlog.Services
 {
+    using Data.Models;
+    using Repository.Contracts;
+
     public class BlogPostAdminService : IBlogPostAdminService
     {
-        private readonly IDbContextFactory<ApplicationDbContext> _contextFactory;
+        private readonly IBlogPostRepository _blogPostRepository;
 
-        public BlogPostAdminService(IDbContextFactory<ApplicationDbContext> contextFactory)
+        public BlogPostAdminService(IBlogPostRepository blogPostRepository)
         {
-            this._contextFactory = contextFactory;
+            _blogPostRepository = blogPostRepository;
         }
 
         public async Task<PageResult<BlogPost>> GetBlogPostsAsync(int startIndex, int pageSize)
         {
-            return await this.ExecuteOnContext(async context =>
-            {
-                var query = context.BlogPosts
-                    .AsNoTracking();
-
-                var count = await query
-                    .CountAsync();
-
-                var results = await query
-                    .Include(b => b.Category)
-                    .OrderByDescending(b => b.CreatedAt)
-                    .Skip(startIndex)
-                    .Take(pageSize)
-                    .ToArrayAsync();
-
-                return new PageResult<BlogPost>(results, count);
-            });
+            return await _blogPostRepository.GetBlogPostsAsync(startIndex, pageSize);
         }
 
-        public async Task<BlogPost?> GetBlogPostByIdAsync(int id) =>
-            await this.ExecuteOnContext(async context =>
-                await context.BlogPosts
-                    .AsNoTracking()
-                    .Include(b => b.Category)
-                    .FirstOrDefaultAsync(b => b.Id == id));
+        public async Task<BlogPost?> GetBlogPostByIdAsync(int id)
+        {
+            return await _blogPostRepository.GetBlogPostByIdAsync(id);
+        }
 
         public async Task<BlogPost> SaveBlogPostAsync(BlogPost blogPost, string userId)
         {
-            return await ExecuteOnContext(async context =>
-            {
-                if (blogPost.Id == 0)
-                {
-                    var isTitleExist = await context.BlogPosts
-                        .AsNoTracking()
-                        .AnyAsync(b => b.Title == blogPost.Title);
-
-                    if (isTitleExist)
-                    {
-                        throw new InvalidOperationException($"A blog post with this same title already exists.");
-                    }
-
-                    blogPost.Slug = await this.GenerateSlugAsync(blogPost);
-
-                    blogPost.CreatedAt = DateTime.UtcNow;
-                    blogPost.UserId = userId;
-
-                    if (blogPost.IsPublished)
-                    {
-                        blogPost.PublishedAt = DateTime.UtcNow;
-                    }
-
-                    await context.BlogPosts.AddAsync(blogPost);
-                }
-                else
-                {
-                    var isTitleExist = await context.BlogPosts
-                        .AsNoTracking()
-                        .AnyAsync(b => b.Title == blogPost.Title && b.Id != blogPost.Id);
-
-                    if (isTitleExist)
-                    {
-                        throw new InvalidOperationException($"A blog post with this same title already exists.");
-                    }
-
-                    var dbBlog = await context.BlogPosts.FindAsync(blogPost.Id);
-
-                    dbBlog.Title = blogPost.Title;
-                    dbBlog.Image = blogPost.Image;
-                    dbBlog.Introduction = blogPost.Introduction;
-                    dbBlog.Content = blogPost.Content;
-                    dbBlog.CategoryId = blogPost.CategoryId;
-
-                    dbBlog.IsPublished = blogPost.IsPublished;
-                    dbBlog.IsFeatured = blogPost.IsFeatured;
-
-                    if (blogPost.IsPublished)
-                    {
-                        if (!dbBlog.IsPublished)
-                        {
-                            blogPost.PublishedAt = DateTime.UtcNow;
-                        }
-                    }
-                    else
-                    {
-                        blogPost.PublishedAt = null;
-                    }
-                }
-
-                await context.SaveChangesAsync();
-                return blogPost;
-            });
+            return await _blogPostRepository.SaveBlogPostAsync(blogPost, userId);
         }
 
         public async Task<bool> DeleteBlogPostAsync(int id)
         {
-            bool result = await this.ExecuteOnContext(async context =>
-            {
-                var blogPost = await context.BlogPosts.FindAsync(id);
-                if (blogPost is null) return false;
-                context.BlogPosts.Remove(blogPost);
-                await context.SaveChangesAsync();
-                return true;
-
-            });
-
-            return result;
-        }
-
-        private async Task<TResult> ExecuteOnContext<TResult>(Func<ApplicationDbContext, Task<TResult>> query)
-        {
-            await using var context = this._contextFactory.CreateDbContext();
-            return await query.Invoke(context);
-        }
-
-        private async Task<string> GenerateSlugAsync(BlogPost blogPost)
-        {
-            return await this.ExecuteOnContext(async context =>
-            {
-                var currentSlug = blogPost.Title.ToSlug();
-                var slug = currentSlug;
-                var count = 1;
-
-                while (await context.BlogPosts.AsNoTracking().AnyAsync(b => b.Slug == slug))
-                {
-                    slug = $"{currentSlug}-{count++}";
-                }
-
-                return slug;
-            });
+            return await _blogPostRepository.DeleteBlogPostAsync(id);
         }
     }
 }

--- a/BlazorBlog.Services/BlogPostService.cs
+++ b/BlazorBlog.Services/BlogPostService.cs
@@ -2,133 +2,45 @@
 {
     using Data.Entities;
     using Contracts;
+    using Data.Models;
+    using global::BlazorBlog.Repository.Contracts;
 
-    public class BlogPostService : IBlogPostService
+    namespace BlazorBlog.Services
     {
-        private readonly IDbContextFactory<ApplicationDbContext> _contextFactory;
-
-        public BlogPostService(IDbContextFactory<ApplicationDbContext> contextFactory)
+        public class BlogPostService : IBlogPostService
         {
-            _contextFactory = contextFactory;
-        }
+            private readonly IBlogPostRepository _blogPostRepository;
 
-        private async Task<TResult> QueryOnContextAsync<TResult>(Func<ApplicationDbContext, Task<TResult>> query)
-        {
-            using var context = _contextFactory.CreateDbContext();
-            return await query(context);
-        }
-
-        public async Task<BlogPost[]> GetFeaturedBlogPostsAsync(int count, int categoryId = 0)
-        {
-            return await QueryOnContextAsync(async context =>
+            public BlogPostService(IBlogPostRepository blogPostRepository)
             {
-                var query = context.BlogPosts
-                    .AsNoTracking()
-                    .Include(p => p.Category)
-                    .Include(p => p.User)
-                    .Where(p => p.IsPublished);
+                _blogPostRepository = blogPostRepository;
+            }
 
-                if (categoryId > 0)
-                {
-                    query = query.Where(p => p.CategoryId == categoryId);
-                }
-
-                var records = await query
-                    .Where(p => p.IsFeatured)
-                    .OrderBy(_ => Guid.NewGuid())
-                    .Take(count)
-                    .ToArrayAsync();
-
-                if (count > records.Length)
-                {
-                    var additionalRecords = await query
-                        .Where(b => !b.IsFeatured)
-                        .OrderBy(_ => Guid.NewGuid())
-                        .Take(count - records.Length)
-                        .ToArrayAsync();
-
-                    records = [.. records, .. additionalRecords];
-                }
-
-                return records;
-            });
-        }
-
-        public async Task<BlogPost[]> GetPopularBlogPostsAsync(int count, int categoryId = 0)
-        {
-            return await QueryOnContextAsync(async context =>
+            public async Task<BlogPost[]> GetFeaturedBlogPostsAsync(int count, int categoryId = 0)
             {
-                var query = context.BlogPosts
-                    .AsNoTracking()
-                    .Include(p => p.Category)
-                    .Include(p => p.User)
-                    .Where(p => p.IsPublished);
+                return await _blogPostRepository.GetFeaturedBlogPostsAsync(count, categoryId);
+            }
 
-                if (categoryId > 0)
-                {
-                    query = query.Where(p => p.CategoryId == categoryId);
-                }
-
-                return await query
-                    .OrderByDescending(p => p.ViewCount)
-                    .Take(count)
-                    .ToArrayAsync();
-            });
-        }
-
-        public async Task<BlogPost[]> GetRecentBlogPostsAsync(int count, int categoryId = 0) => await GetPostsAsync(0, count, categoryId);
-
-        public async Task<BlogPost[]> GetBlogPostsAsync(int pageIndex, int pageSize, int categoryId) => await GetPostsAsync(pageIndex * pageSize, pageSize, categoryId);
-
-        public async Task<DetailPageModel> GetBlogPostBySlugAsync(string slug)
-        {
-            return await QueryOnContextAsync(async context =>
+            public async Task<BlogPost[]> GetPopularBlogPostsAsync(int count, int categoryId = 0)
             {
-                var blogPost = await context.BlogPosts
-                    .AsNoTracking()
-                    .Include(p => p.Category)
-                    .Include(p => p.User)
-                    .FirstOrDefaultAsync(p => p.Slug == slug && p.IsPublished);
+                return await _blogPostRepository.GetPopularBlogPostsAsync(count, categoryId);
+            }
 
-                if (blogPost is null)
-                {
-                    return DetailPageModel.Empty();
-                }
-
-                var relatedPosts = await context.BlogPosts
-                    .AsNoTracking()
-                    .Include(p => p.Category)
-                    .Include(p => p.User)
-                    .Where(p => p.CategoryId == blogPost.CategoryId && p.IsPublished)
-                    .OrderBy(_ => Guid.NewGuid())
-                    .Take(4)
-                    .ToArrayAsync();
-
-                return new DetailPageModel(blogPost, relatedPosts);
-            });
-        }
-
-        private async Task<BlogPost[]> GetPostsAsync(int skip, int take, int categoryId = 0)
-        {
-            return await QueryOnContextAsync(async context =>
+            public async Task<BlogPost[]> GetRecentBlogPostsAsync(int count, int categoryId = 0)
             {
-                var query = context.BlogPosts
-                    .AsNoTracking()
-                    .Include(p => p.Category)
-                    .Include(p => p.User)
-                    .Where(p => p.IsPublished);
+                return await _blogPostRepository.GetRecentBlogPostsAsync(count, categoryId);
+            }
 
-                if (categoryId > 0)
-                {
-                    query = query.Where(p => p.CategoryId == categoryId);
-                }
+            public async Task<BlogPost[]> GetBlogPostsAsync(int pageIndex, int pageSize, int categoryId)
+            {
+                return await _blogPostRepository.GetBlogPostsAsync(pageIndex, pageSize, categoryId);
+            }
 
-                return await query
-                    .OrderByDescending(p => p.PublishedAt)
-                    .Skip(skip)
-                    .Take(take)
-                    .ToArrayAsync();
-            });
+            public async Task<DetailPageModel> GetBlogPostBySlugAsync(string slug)
+            {
+                return await _blogPostRepository.GetBlogPostBySlugAsync(slug);
+            }
         }
     }
+
 }

--- a/BlazorBlog.Services/Contracts/IBlogPostAdminService.cs
+++ b/BlazorBlog.Services/Contracts/IBlogPostAdminService.cs
@@ -1,4 +1,6 @@
-﻿namespace BlazorBlog.Services.Contracts
+﻿using BlazorBlog.Data.Models;
+
+namespace BlazorBlog.Services.Contracts
 {
     public interface IBlogPostAdminService
     {

--- a/BlazorBlog.Services/Contracts/ISubscribeService.cs
+++ b/BlazorBlog.Services/Contracts/ISubscribeService.cs
@@ -1,4 +1,6 @@
-﻿namespace BlazorBlog.Services.Contracts;
+﻿using BlazorBlog.Data.Models;
+
+namespace BlazorBlog.Services.Contracts;
 
 public interface ISubscribeService
 {

--- a/BlazorBlog.Services/GlobalUsings.cs
+++ b/BlazorBlog.Services/GlobalUsings.cs
@@ -6,7 +6,6 @@ global using BlazorBlog.Data;
 global using BlazorBlog.Data.Entities;
 global using BlazorBlog.Services.Contracts;
 global using BlazorBlog.Services.Settings;
-global using BlazorBlog.Services.Models;
 global using BlazorBlog.Services.Common;
 
 global using Microsoft.AspNetCore.Identity;

--- a/BlazorBlog.Services/SubscribeService.cs
+++ b/BlazorBlog.Services/SubscribeService.cs
@@ -1,49 +1,25 @@
 ﻿namespace BlazorBlog.Services
 {
+    using Data.Models;
+    using Repository.Contracts;
+
     public class SubscribeService : ISubscribeService
     {
-        private readonly IDbContextFactory<ApplicationDbContext> _contextFactory;
+        private readonly ISubscriberRepository _subscriberRepository;
 
-        public SubscribeService(IDbContextFactory<ApplicationDbContext> contextFactory)
+        public SubscribeService(ISubscriberRepository subscriberRepository)
         {
-            _contextFactory = contextFactory;
+            _subscriberRepository = subscriberRepository;
         }
 
         public async Task<string?> AddSubscriberAsync(Subscriber subscriber)
         {
-            using var context = _contextFactory.CreateDbContext();
-
-            var existingSubscriber = await context.Subscribers
-                .FirstOrDefaultAsync(s => s.Email == subscriber.Email);
-
-            if (existingSubscriber != null)
-            {
-                return "You are already subscribed.";
-            }
-
-            subscriber.SubscribedOn = DateTime.UtcNow;
-
-            await context.Subscribers.AddAsync(subscriber);
-            await context.SaveChangesAsync();
-
-            return null;
+            return await _subscriberRepository.AddSubscriberAsync(subscriber);
         }
 
         public async Task<PageResult<Subscriber>> GetSubscribersAsync(int startIndex, int pageSize)
         {
-            using var context = _contextFactory.CreateDbContext();
-            var query = context.Subscribers
-                .AsNoTracking()
-                .OrderByDescending(s => s.SubscribedOn);
-
-            var totalRecords = await query.CountAsync();
-
-            var records = await query
-                .Skip(startIndex)
-                .Take(pageSize)
-                .ToArrayAsync();
-
-            return new PageResult<Subscriber>(records, totalRecords);
+            return await _subscriberRepository.GetSubscribersAsync(startIndex, pageSize);
         }
     }
 }

--- a/BlazorBlog/Components/_Imports.razor
+++ b/BlazorBlog/Components/_Imports.razor
@@ -20,5 +20,4 @@
 @using BlazorBlog.Data.Entities
 @using BlazorBlog.Services.Common
 @using BlazorBlog.Services.Contracts
-@using BlazorBlog.Services.Models
 @using BlazorBlog.Services.Utilities

--- a/BlazorBlog/Program.cs
+++ b/BlazorBlog/Program.cs
@@ -1,11 +1,14 @@
 namespace BlazorBlog
 {
+    using Services.BlazorBlog.Services;
     using Components.Account;
     using Data;
     using Services;
     using Ganss.Xss;
     using Microsoft.AspNetCore.Identity;
     using Microsoft.EntityFrameworkCore;
+    using Repository.Contracts;
+    using Repository;
 
     public class Program
     {
@@ -47,11 +50,14 @@ namespace BlazorBlog
             builder.Services.AddScoped<IToastService, ToastService>();
 
             builder.Services
-                .AddTransient<ISeedService, SeedService>()
-                .AddTransient<ICategoryService, CategoryService>()
-                .AddTransient<IBlogPostAdminService, BlogPostAdminService>()
-                .AddTransient<IBlogPostService, BlogPostService>()
-                .AddTransient<ISubscribeService, SubscribeService>();
+                .AddScoped<ISeedService, SeedService>()
+                .AddScoped<ICategoryService, CategoryService>()
+                .AddScoped<IBlogPostAdminService, BlogPostAdminService>()
+                .AddScoped<IBlogPostService, BlogPostService>()
+                .AddScoped<ISubscribeService, SubscribeService>()
+                .AddScoped<IBlogPostRepository, BlogPostRepository>()
+                .AddScoped<ICategoryRepository, CategoryRepository>()
+                .AddScoped<ISubscriberRepository, SubscriberRepository>();
 
             builder.Services.AddSingleton<IHtmlSanitizer, HtmlSanitizer>(provider =>
             {


### PR DESCRIPTION
- Create repository interfaces (IBlogPostRepository, ICategoryRepository, ISubscriberRepository) and implement them in respective classes.
- Refactor BlogPostService, BlogPostAdminService, CategoryService, and SubscribeService to use the new repository pattern for data access.
- Move data access logic from service methods to repository methods, ensuring separation of concerns.
- Update service constructors to inject repository interfaces instead of DbContextFactory.
- Optimize data queries and ensure proper asynchronous operation handling in repository methods.

This commit centralizes data access logic into repositories, enhancing the modularity, maintainability, and testability of the codebase. It also simplifies the service layers by focusing them on business logic and delegating data handling to the repositories.