### PR TITLE
Add CI Workflow, Remove Unused Package, and Improve Error Handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,51 @@
+name: CI
+
+on:
+  push:
+    branches: [main, dev]
+  pull_request:
+    branches: [main, dev]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "9.0.x"
+
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj') }}
+          restore-keys: |
+            ${{ runner.os }}-nuget-
+
+      - name: Restore
+        run: dotnet restore BlazorBlog.sln
+
+      - name: Build (Release)
+        run: dotnet build BlazorBlog.sln -c Release --no-restore
+
+      - name: Test
+        run: dotnet test BlazorBlog.sln -c Release --no-build --logger "trx;LogFileName=test_results.trx" --results-directory "TestResults"
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results
+          path: TestResults/**/*.trx

--- a/BlazorBlog/BlazorBlog.csproj
+++ b/BlazorBlog/BlazorBlog.csproj
@@ -12,7 +12,6 @@
     <PackageReference Include="HtmlSanitizer" Version="9.0.886">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-  <PackageReference Include="AngleSharp" Version="1.3.0" />
   <PackageReference Include="AngleSharp.Css" Version="0.17.0" />
     <PackageReference Include="Microsoft.AspNetCore.Components.QuickGrid" Version="9.0.8" />
   <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="9.0.8" />

--- a/BlazorBlog/Components/Pages/Admin/ManageCategories.razor.cs
+++ b/BlazorBlog/Components/Pages/Admin/ManageCategories.razor.cs
@@ -120,7 +120,7 @@
                 }
                 catch (InvalidOperationException ex)
                 {
-                    var nameField = new FieldIdentifier(_operatingCategory, nameof(Category.Name));
+                    var nameField = new FieldIdentifier(_operatingCategory!, nameof(Category.Name));
                     _messageStore.Add(nameField, ex.Message);
                     _editContext.NotifyValidationStateChanged();
 

--- a/BlazorBlog/Components/Pages/Admin/SaveBlogPost.razor.cs
+++ b/BlazorBlog/Components/Pages/Admin/SaveBlogPost.razor.cs
@@ -8,38 +8,40 @@
     {
         private const int MaxFileLenght = 10 * 1024 * 1024;
 
-        private bool _isLoading;
-        private string? _loadingText;
+        private bool _isLoading = false;
+        private string? _loadingText = null;
         private BlogPostVm _blogPostVm = new BlogPostVm();
         private EditContext _editContext = default!;
         private ValidationMessageStore? _messageStore;
         private BlazoredTextEditor? _quillHtml;
         private Category[] _categories = [];
         private string? _content = default!;
-    private string? _errorMessage = null;
+        private string? _errorMessage = null;
         private IBrowserFile? _fileToUpload;
         private string? _imageUrl;
         private string PageTitle => Id is > 0 ? "Edit Blog Post" : "New Blog Post";
-    private bool _isSaving;
-    public bool IsSaving => _isSaving;
-    public string TagsCsv { get; set; } = string.Empty;
+        private bool _isSaving;
+        public bool IsSaving => _isSaving;
+        public string TagsCsv { get; set; } = string.Empty;
 
         private readonly CancellationTokenSource _cts = new();
 
-    [Inject] AuthenticationStateProvider AuthenticationStateProvider { get; set; } = default!;
-    [Inject] IWebHostEnvironment WebHostEnvironment { get; set; } = default!;
-    [Inject] IBlogPostAdminService BlogPostService { get; set; } = default!;
-    [Inject] ICategoryService CategoryService { get; set; } = default!;
-    [Inject] NavigationManager NavigationManager { get; set; } = default!;
-    [Inject] IToastService ToastService { get; set; } = default!;
-    [Inject] IHtmlSanitizer HtmlSanitizer { get; set; } = default!;
-    [Inject] IValidator<BlogPostVm> Validator { get; set; } = default!;
-    [Inject] ITagService TagService { get; set; } = default!;
+        [Inject] AuthenticationStateProvider AuthenticationStateProvider { get; set; } = default!;
+        [Inject] IWebHostEnvironment WebHostEnvironment { get; set; } = default!;
+        [Inject] IBlogPostAdminService BlogPostService { get; set; } = default!;
+        [Inject] ICategoryService CategoryService { get; set; } = default!;
+        [Inject] NavigationManager NavigationManager { get; set; } = default!;
+        [Inject] IToastService ToastService { get; set; } = default!;
+        [Inject] IHtmlSanitizer HtmlSanitizer { get; set; } = default!;
+        [Inject] IValidator<BlogPostVm> Validator { get; set; } = default!;
+        [Inject] ITagService TagService { get; set; } = default!;
 
         [Parameter] public int? Id { get; set; }
 
         protected override async Task OnInitializedAsync()
         {
+            _isLoading = true;
+            _loadingText = "Loading blog post...";
             _editContext = new EditContext(_blogPostVm);
             _messageStore = new ValidationMessageStore(_editContext);
 
@@ -67,6 +69,8 @@
                 }
                 catch { /* optional */ }
             }
+            _isLoading = false;
+            _loadingText = null;
         }
 
         private async Task PreviewImageAsync(IBrowserFile file)
@@ -130,6 +134,8 @@
             }
 
             _isSaving = true;
+            _isLoading = true;
+            _loadingText = "Saving blog post...";
             StateHasChanged();
             await SaveBlogPostAsync();
         }
@@ -189,6 +195,11 @@
             {
                 ToastService.ShowToast(ToastLevel.Error, "Something went wrong while saving the blog post.", heading: "Error");
                 _isSaving = false;
+            }
+            finally
+            {
+                _isLoading = false;
+                _loadingText = null;
             }
         }
 


### PR DESCRIPTION
#### PR Classification
This pull request introduces a new CI workflow, removes an unnecessary package, and improves error handling and user feedback in the application.

#### PR Summary
The changes establish a CI workflow for building and testing a .NET application, remove the `AngleSharp` package from the project, and enhance the handling of loading states in the `SaveBlogPost.razor.cs` file. 
- `ci.yml`: Added a CI workflow for pushes and pull requests to `main` and `dev` branches, including build and test steps.
- `BlazorBlog.csproj`: Removed the `AngleSharp` package reference.
- `ManageCategories.razor.cs`: Added nullability operator to `_operatingCategory` for safer code.
- `SaveBlogPost.razor.cs`: Initialized `_isLoading` and `_loadingText`, and added a `finally` block to manage loading state during save operations.
