### PR TITLE
Add unit tests for various services and components

### DIFF
--- a/BlazorBlog.Tests/Component/AllPostsPageTests.cs
+++ b/BlazorBlog.Tests/Component/AllPostsPageTests.cs
@@ -1,0 +1,79 @@
+namespace BlazorBlog.Tests.Component
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Bunit;
+    using Microsoft.Extensions.DependencyInjection;
+    using Moq;
+    using Xunit;
+    using BlazorBlog.Components.Pages;
+    using BlazorBlog.Application.Contracts;
+    using BlazorBlog.Application.Models;
+    using BlazorBlog.Domain.Entities;
+    using BlazorBlog.Application.UI;
+    using BlazorBlog.Infrastructure;
+    using BlazorBlog.Infrastructure.Contracts;
+    using FluentValidation;
+
+    public class AllPostsPageTests
+    {
+        [Fact]
+        public void AllPosts_Renders_NoPosts_State()
+        {
+            using var ctx = new TestContext();
+
+            var blogMock = new Mock<IBlogPostService>(MockBehavior.Strict);
+            blogMock.Setup(s => s.GetBlogPostsAsync(0, 8, 0, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(System.Array.Empty<BlogPostVm>());
+            blogMock.Setup(s => s.GetPopularBlogPostsAsync(5, 0, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(System.Array.Empty<BlogPostVm>());
+
+            var catMock = new Mock<ICategoryService>(MockBehavior.Strict);
+            catMock.Setup(s => s.GetCategoriesAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(System.Array.Empty<Category>());
+
+            ctx.Services.AddSingleton(blogMock.Object);
+            ctx.Services.AddSingleton(catMock.Object);
+            ctx.Services.AddSingleton<IToastService, ToastService>();
+            ctx.Services.AddSingleton<ISubscribeService, BlazorBlog.Tests.Component.DummySubscribeService>();
+            ctx.Services.AddScoped<IValidator<BlazorBlog.Domain.Entities.Subscriber>, BlazorBlog.Tests.Component.DummySubscriberValidator>();
+
+            var cut = ctx.RenderComponent<AllPosts>();
+            cut.WaitForAssertion(() => Assert.Contains("All Posts", cut.Markup));
+            Assert.Contains("No posts yet", cut.Markup);
+        }
+
+        [Fact]
+        public async Task AllPosts_Changing_PageNumber_Loads_New_Page()
+        {
+            using var ctx = new TestContext();
+
+            var blogMock = new Mock<IBlogPostService>(MockBehavior.Strict);
+            // Initial load for page 1
+            blogMock.Setup(s => s.GetBlogPostsAsync(0, 8, 0, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(System.Array.Empty<BlogPostVm>())
+                .Verifiable();
+            blogMock.Setup(s => s.GetPopularBlogPostsAsync(5, 0, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(System.Array.Empty<BlogPostVm>());
+            var catMock = new Mock<ICategoryService>(MockBehavior.Strict);
+            catMock.Setup(s => s.GetCategoriesAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(System.Array.Empty<Category>());
+
+            // When page changes to 2, pageIndex becomes 1
+            blogMock.Setup(s => s.GetBlogPostsAsync(1, 8, 0, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(System.Array.Empty<BlogPostVm>())
+                .Verifiable();
+
+            ctx.Services.AddSingleton(blogMock.Object);
+            ctx.Services.AddSingleton(catMock.Object);
+            ctx.Services.AddSingleton<IToastService, ToastService>();
+            ctx.Services.AddSingleton<ISubscribeService, BlazorBlog.Tests.Component.DummySubscribeService>();
+            ctx.Services.AddScoped<IValidator<BlazorBlog.Domain.Entities.Subscriber>, BlazorBlog.Tests.Component.DummySubscriberValidator>();
+
+            var cut = ctx.RenderComponent<AllPosts>(p => p.Add(x => x.PageNumber, 1));
+            await cut.InvokeAsync(() => cut.SetParametersAndRender(parameters => parameters.Add(x => x.PageNumber, 2)));
+
+            blogMock.VerifyAll();
+        }
+    }
+}

--- a/BlazorBlog.Tests/Component/BlogPostDetailPageTests.cs
+++ b/BlazorBlog.Tests/Component/BlogPostDetailPageTests.cs
@@ -1,0 +1,61 @@
+namespace BlazorBlog.Tests.Component
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Bunit;
+    using Microsoft.AspNetCore.Components;
+    using Microsoft.Extensions.DependencyInjection;
+    using Moq;
+    using Xunit;
+    using BlazorBlog.Components.Pages;
+    using BlazorBlog.Application.Contracts;
+    using BlazorBlog.Application.Models;
+    using FluentValidation;
+    using BlazorBlog.Infrastructure.Contracts;
+
+    public class BlogPostDetailPageTests
+    {
+        [Fact]
+        public void Navigates_Home_When_Empty_Result()
+        {
+            using var ctx = new TestContext();
+            var blog = new Mock<IBlogPostService>(MockBehavior.Strict);
+            blog.Setup(s => s.GetBlogPostBySlugAsync("missing", It.IsAny<CancellationToken>()))
+                .ReturnsAsync(DetailPageModel.Empty());
+            ctx.Services.AddSingleton(blog.Object);
+
+            var nav = ctx.Services.GetRequiredService<NavigationManager>();
+            var cut = ctx.RenderComponent<BlogPostDetail>(p => p.Add(x => x.BlogPostSlug, "missing"));
+            // Blazor TestContext provides base URI http://localhost/
+            Assert.StartsWith("http://localhost/", nav.Uri);
+        }
+
+        [Fact]
+        public void Shows_Post_And_Loads_Popular_In_Category()
+        {
+            using var ctx = new TestContext();
+            var blog = new Mock<IBlogPostService>(MockBehavior.Strict);
+
+            var vm = new BlogPostVm
+            {
+                Id = 1,
+                Title = "Post",
+                CategoryId = 7,
+                Content = "<p>Hello world content</p>"
+            };
+            blog.Setup(s => s.GetBlogPostBySlugAsync("ok", It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new DetailPageModel(vm, System.Array.Empty<BlogPostVm>()));
+            blog.Setup(s => s.GetPopularBlogPostsAsync(4, 7, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(System.Array.Empty<BlogPostVm>());
+
+            ctx.Services.AddSingleton(blog.Object);
+            // Register DI required by SubscribeBox
+            ctx.Services.AddSingleton<ISubscribeService, BlazorBlog.Tests.Component.DummySubscribeService>();
+            ctx.Services.AddScoped<IValidator<BlazorBlog.Domain.Entities.Subscriber>, BlazorBlog.Tests.Component.DummySubscriberValidator>();
+
+            var cut = ctx.RenderComponent<BlogPostDetail>(p => p.Add(x => x.BlogPostSlug, "ok"));
+            // Should not navigate; ensures render
+            Assert.Contains("Post", cut.Markup);
+        }
+    }
+}

--- a/BlazorBlog.Tests/Services/BlogCacheSignalTests.cs
+++ b/BlazorBlog.Tests/Services/BlogCacheSignalTests.cs
@@ -1,0 +1,18 @@
+namespace BlazorBlog.Tests.Services
+{
+    using BlazorBlog.Infrastructure.Utilities;
+    using Xunit;
+
+    public class BlogCacheSignalTests
+    {
+        [Fact]
+        public void Bump_Increments_Version_Atomically()
+        {
+            var s = new BlogCacheSignal();
+            var before = s.Version;
+            s.Bump();
+            s.Bump();
+            Assert.True(s.Version > before);
+        }
+    }
+}

--- a/BlazorBlog.Tests/Services/BlogPostAdminServiceForwardersTests.cs
+++ b/BlazorBlog.Tests/Services/BlogPostAdminServiceForwardersTests.cs
@@ -1,0 +1,53 @@
+namespace BlazorBlog.Tests.Services
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+    using BlazorBlog.Application.Contracts;
+    using BlazorBlog.Domain.Entities;
+    using BlazorBlog.Infrastructure;
+    using BlazorBlog.Infrastructure.Utilities;
+    using Moq;
+    using Xunit;
+
+    public class BlogPostAdminServiceForwardersTests
+    {
+        [Fact]
+        public async Task GetBlogPostsAsync_ForwardsToRepository()
+        {
+            var repo = new Mock<IBlogPostAdminRepository>(MockBehavior.Strict);
+            var svc = new BlogPostAdminService(repo.Object, new SlugService(), new BlogCacheSignal());
+            repo.Setup(r => r.GetBlogPostsAsync(0, 10, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new BlazorBlog.Application.Models.PageResult<BlogPost>(System.Array.Empty<BlogPost>(), 0));
+            var result = await svc.GetBlogPostsAsync(0, 10);
+            Assert.Equal(0, result.TotalCount);
+            repo.VerifyAll();
+        }
+
+        [Fact]
+        public async Task GetBlogPostByIdAsync_ForwardsToRepository()
+        {
+            var repo = new Mock<IBlogPostAdminRepository>(MockBehavior.Strict);
+            var svc = new BlogPostAdminService(repo.Object, new SlugService(), new BlogCacheSignal());
+            repo.Setup(r => r.GetBlogPostByIdAsync(5, It.IsAny<CancellationToken>()))
+                .ReturnsAsync((BlogPost?)null);
+            var result = await svc.GetBlogPostByIdAsync(5);
+            Assert.Null(result);
+            repo.VerifyAll();
+        }
+
+        [Fact]
+        public async Task DeleteBlogPostAsync_Forwards_And_Bumps_Signal_When_Deleted()
+        {
+            var repo = new Mock<IBlogPostAdminRepository>(MockBehavior.Strict);
+            var signal = new BlogCacheSignal();
+            var svc = new BlogPostAdminService(repo.Object, new SlugService(), signal);
+            var before = signal.Version;
+            repo.Setup(r => r.DeleteBlogPostAsync(7, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(true);
+            var ok = await svc.DeleteBlogPostAsync(7);
+            Assert.True(ok);
+            Assert.True(signal.Version > before);
+            repo.VerifyAll();
+        }
+    }
+}

--- a/BlazorBlog.Tests/Services/BlogPostServiceTests.cs
+++ b/BlazorBlog.Tests/Services/BlogPostServiceTests.cs
@@ -62,5 +62,127 @@ namespace BlazorBlog.Tests.Services
             Assert.Equal(123, result.BlogPost.Id);
             repo.VerifyAll();
         }
+
+        [Fact]
+        public async Task GetFeaturedBlogPostsAsync_UsesCache_AndSignalInvalidates()
+        {
+            var posts = new[] { new BlogPostVm { Id = 2, Title = "F" } };
+            var svc = CreateService(out var repo, out var signal);
+
+            repo.Setup(r => r.GetFeaturedBlogPostsAsync(5, 0, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(posts)
+                .Verifiable();
+
+            var first = await svc.GetFeaturedBlogPostsAsync(5);
+            Assert.Single(first);
+
+            var second = await svc.GetFeaturedBlogPostsAsync(5);
+            Assert.Single(second);
+            repo.Verify(r => r.GetFeaturedBlogPostsAsync(5, 0, It.IsAny<CancellationToken>()), Times.Once);
+
+            signal.Bump();
+            repo.Setup(r => r.GetFeaturedBlogPostsAsync(5, 0, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(posts);
+            var third = await svc.GetFeaturedBlogPostsAsync(5);
+            Assert.Single(third);
+            repo.Verify(r => r.GetFeaturedBlogPostsAsync(5, 0, It.IsAny<CancellationToken>()), Times.Exactly(2));
+        }
+
+        [Fact]
+        public async Task GetPopularBlogPostsAsync_UsesCache_AndSignalInvalidates()
+        {
+            var posts = new[] { new BlogPostVm { Id = 3, Title = "P" } };
+            var svc = CreateService(out var repo, out var signal);
+
+            repo.Setup(r => r.GetPopularBlogPostsAsync(4, 0, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(posts)
+                .Verifiable();
+
+            var first = await svc.GetPopularBlogPostsAsync(4);
+            Assert.Single(first);
+
+            var second = await svc.GetPopularBlogPostsAsync(4);
+            Assert.Single(second);
+            repo.Verify(r => r.GetPopularBlogPostsAsync(4, 0, It.IsAny<CancellationToken>()), Times.Once);
+
+            signal.Bump();
+            repo.Setup(r => r.GetPopularBlogPostsAsync(4, 0, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(posts);
+            var third = await svc.GetPopularBlogPostsAsync(4);
+            Assert.Single(third);
+            repo.Verify(r => r.GetPopularBlogPostsAsync(4, 0, It.IsAny<CancellationToken>()), Times.Exactly(2));
+        }
+
+        [Fact]
+        public async Task GetRecentBlogPostsByTagAsync_UsesCache_AndSignalInvalidates()
+        {
+            var posts = new[] { new BlogPostVm { Id = 10, Title = "T" } };
+            var svc = CreateService(out var repo, out var signal);
+
+            repo.Setup(r => r.GetRecentBlogPostsByTagAsync("tag", 2, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(posts)
+                .Verifiable();
+
+            var first = await svc.GetRecentBlogPostsByTagAsync("tag", 2);
+            Assert.Single(first);
+
+            var second = await svc.GetRecentBlogPostsByTagAsync("tag", 2);
+            Assert.Single(second);
+            repo.Verify(r => r.GetRecentBlogPostsByTagAsync("tag", 2, It.IsAny<CancellationToken>()), Times.Once);
+
+            signal.Bump();
+            repo.Setup(r => r.GetRecentBlogPostsByTagAsync("tag", 2, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(posts);
+            var third = await svc.GetRecentBlogPostsByTagAsync("tag", 2);
+            Assert.Single(third);
+            repo.Verify(r => r.GetRecentBlogPostsByTagAsync("tag", 2, It.IsAny<CancellationToken>()), Times.Exactly(2));
+        }
+
+        [Fact]
+        public async Task GetPopularBlogPostsByTagAsync_UsesCache_AndSignalInvalidates()
+        {
+            var posts = new[] { new BlogPostVm { Id = 11, Title = "TP" } };
+            var svc = CreateService(out var repo, out var signal);
+
+            repo.Setup(r => r.GetPopularBlogPostsByTagAsync("tag", 2, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(posts)
+                .Verifiable();
+
+            var first = await svc.GetPopularBlogPostsByTagAsync("tag", 2);
+            Assert.Single(first);
+
+            var second = await svc.GetPopularBlogPostsByTagAsync("tag", 2);
+            Assert.Single(second);
+            repo.Verify(r => r.GetPopularBlogPostsByTagAsync("tag", 2, It.IsAny<CancellationToken>()), Times.Once);
+
+            signal.Bump();
+            repo.Setup(r => r.GetPopularBlogPostsByTagAsync("tag", 2, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(posts);
+            var third = await svc.GetPopularBlogPostsByTagAsync("tag", 2);
+            Assert.Single(third);
+            repo.Verify(r => r.GetPopularBlogPostsByTagAsync("tag", 2, It.IsAny<CancellationToken>()), Times.Exactly(2));
+        }
+
+        [Fact]
+        public async Task GetBlogPostsAsync_ForwardsToRepository()
+        {
+            var svc = CreateService(out var repo, out _);
+            repo.Setup(r => r.GetBlogPostsAsync(1, 10, 0, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(Array.Empty<BlogPostVm>());
+            var result = await svc.GetBlogPostsAsync(1, 10, 0);
+            Assert.Empty(result);
+            repo.VerifyAll();
+        }
+
+        [Fact]
+        public async Task GetBlogPostsByTagAsync_ForwardsToRepository()
+        {
+            var svc = CreateService(out var repo, out _);
+            repo.Setup(r => r.GetBlogPostsByTagAsync("tag", 0, 10, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(Array.Empty<BlogPostVm>());
+            var result = await svc.GetBlogPostsByTagAsync("tag", 0, 10);
+            Assert.Empty(result);
+            repo.VerifyAll();
+        }
     }
 }

--- a/BlazorBlog.Tests/Services/TagAndSubscribeServiceTests.cs
+++ b/BlazorBlog.Tests/Services/TagAndSubscribeServiceTests.cs
@@ -1,0 +1,54 @@
+namespace BlazorBlog.Tests.Services
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+    using BlazorBlog.Application.Contracts;
+    using BlazorBlog.Application.Models;
+    using BlazorBlog.Domain.Entities;
+    using BlazorBlog.Infrastructure;
+    using Moq;
+    using Xunit;
+
+    public class TagAndSubscribeServiceTests
+    {
+        [Fact]
+        public async Task TagService_Forwards_All_Methods_To_Repository()
+        {
+            var repo = new Mock<ITagRepository>(MockBehavior.Strict);
+            var svc = new TagService(repo.Object);
+
+            repo.Setup(r => r.GetTopTagsAsync(5, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(System.Array.Empty<TagVm>());
+            repo.Setup(r => r.GetTagsForPostAsync(12, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(System.Array.Empty<string>());
+            repo.Setup(r => r.SetTagsForPostAsync(12, It.IsAny<string[]>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+
+            Assert.Empty(await svc.GetTopTagsAsync(5));
+            Assert.Empty(await svc.GetTagsForPostAsync(12));
+            await svc.SetTagsForPostAsync(12, new[] { "x" });
+
+            repo.VerifyAll();
+        }
+
+        [Fact]
+        public async Task SubscribeService_Forwards_All_Methods_To_Repository()
+        {
+            var repo = new Mock<ISubscriberRepository>(MockBehavior.Strict);
+            var svc = new SubscribeService(repo.Object);
+
+            var page = new PageResult<Subscriber>(System.Array.Empty<Subscriber>(), 0);
+            repo.Setup(r => r.AddSubscriberAsync(It.IsAny<Subscriber>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((string?)null);
+            repo.Setup(r => r.GetSubscribersAsync(0, 10, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(page);
+
+            var err = await svc.AddSubscriberAsync(new Subscriber { Email = "e@x.com", Name = "n" });
+            Assert.Null(err);
+            var subs = await svc.GetSubscribersAsync(0, 10);
+            Assert.Equal(0, subs.TotalCount);
+
+            repo.VerifyAll();
+        }
+    }
+}

--- a/BlazorBlog.Tests/Services/ToastServiceAndExtensionsTests.cs
+++ b/BlazorBlog.Tests/Services/ToastServiceAndExtensionsTests.cs
@@ -1,0 +1,60 @@
+namespace BlazorBlog.Tests.Services
+{
+    using BlazorBlog.Application.UI;
+    using BlazorBlog.Infrastructure;
+    using Xunit;
+
+    public class ToastServiceAndExtensionsTests
+    {
+        [Fact]
+        public void ToastService_Raises_OnShow_For_ShowToast_And_RemoveAll()
+        {
+            var svc = new ToastService();
+            int calls = 0;
+            ToastLevel lastLevel = default;
+            string lastMessage = string.Empty;
+            string lastHeading = string.Empty;
+            int? lastDuration = null;
+
+            svc.OnShow += (lvl, msg, hdg, dur) => { calls++; lastLevel = lvl; lastMessage = msg; lastHeading = hdg; lastDuration = dur; };
+
+            svc.ShowToast(ToastLevel.Success, "hello", "hi", 2500);
+            Assert.Equal(1, calls);
+            Assert.Equal(ToastLevel.Success, lastLevel);
+            Assert.Equal("hello", lastMessage);
+            Assert.Equal("hi", lastHeading);
+            Assert.Equal(2500, lastDuration);
+
+            svc.RemoveAll();
+            Assert.Equal(2, calls);
+            Assert.Equal(string.Empty, lastMessage);
+        }
+
+        [Theory]
+        [InlineData(2, 2000)]
+        [InlineData(null, null)]
+        [InlineData(0, null)]
+        public void ToastExtensions_Converts_Seconds_To_Milliseconds(int? seconds, int? expectedMs)
+        {
+            var svc = new ToastService();
+            int? seen = null;
+            svc.OnShow += (_, _, _, dur) => seen = dur;
+
+            // Explicitly call the extension method to avoid instance overload
+            ToastServiceExtensions.ShowToast(svc, ToastLevel.Info, "m", "h", seconds);
+            Assert.Equal(expectedMs, seen);
+        }
+
+        [Fact]
+        public void ToastExtensions_Overflow_Sets_Max_Day()
+        {
+            var svc = new ToastService();
+            int? seen = null;
+            svc.OnShow += (_, _, _, dur) => seen = dur;
+
+            // int.MaxValue seconds would overflow when multiplied by 1000
+            ToastServiceExtensions.ShowToast(svc, ToastLevel.Info, "m", "h", int.MaxValue);
+            Assert.Equal(24 * 60 * 60 * 1000, seen);
+        }
+    }
+}

--- a/BlazorBlog.Tests/Utilities/ReadingTimeCalculatorTests.cs
+++ b/BlazorBlog.Tests/Utilities/ReadingTimeCalculatorTests.cs
@@ -1,0 +1,28 @@
+namespace BlazorBlog.Tests.Utilities
+{
+    using BlazorBlog.Application.Utilities;
+    using Xunit;
+
+    public class ReadingTimeCalculatorTests
+    {
+        [Theory]
+        [InlineData("", "0 min read", 0)]
+        [InlineData("<p>Hello world</p>", "1 min read", 2)]
+        public void Calculate_FromHtml_Produces_Time_And_Count(string html, string expectedTime, int expectedCount)
+        {
+            var (time, count) = ReadingTimeCalculator.Calculate(html);
+            Assert.Equal(expectedTime, time);
+            Assert.Equal(expectedCount, count);
+        }
+
+        [Theory]
+        [InlineData(0, "0 min read")]
+        [InlineData(1, "1 min read")]
+        [InlineData(400, "2 min read")]
+        public void CalculateFromWordCount_Works(int words, string expected)
+        {
+            var time = ReadingTimeCalculator.CalculateFromWordCount(words);
+            Assert.Equal(expected, time);
+        }
+    }
+}

--- a/BlazorBlog.Tests/Validation/ValidatorsTests.cs
+++ b/BlazorBlog.Tests/Validation/ValidatorsTests.cs
@@ -1,0 +1,58 @@
+namespace BlazorBlog.Tests.Validation
+{
+    using BlazorBlog.Application.Models;
+    using BlazorBlog.Application.Validators;
+    using BlazorBlog.Domain.Entities;
+    using Xunit;
+
+    public class ValidatorsTests
+    {
+        [Fact]
+        public void BlogPostVmValidator_Validates_Fields()
+        {
+            var v = new BlogPostVmValidator();
+            var invalid = new BlogPostVm();
+            var res = v.Validate(invalid);
+            Assert.Contains(res.Errors, e => e.PropertyName == nameof(BlogPostVm.Title));
+            Assert.Contains(res.Errors, e => e.PropertyName == nameof(BlogPostVm.Image));
+            Assert.Contains(res.Errors, e => e.PropertyName == nameof(BlogPostVm.Introduction));
+            Assert.Contains(res.Errors, e => e.PropertyName == nameof(BlogPostVm.Content));
+            Assert.Contains(res.Errors, e => e.PropertyName == nameof(BlogPostVm.CategoryId));
+
+            var valid = new BlogPostVm
+            {
+                Title = new string('a', 10),
+                Image = "img.png",
+                Introduction = "intro",
+                Content = "content",
+                CategoryId = 1
+            };
+            Assert.True(v.Validate(valid).IsValid);
+        }
+
+        [Fact]
+        public void CategoryValidator_Validates_Fields()
+        {
+            var v = new CategoryValidator();
+            var invalid = new Category();
+            var res = v.Validate(invalid);
+            Assert.Contains(res.Errors, e => e.PropertyName == nameof(Category.Name));
+
+            var valid = new Category { Name = "C#", Slug = new string('s', 10) };
+            Assert.True(v.Validate(valid).IsValid);
+        }
+
+        [Fact]
+        public void SubscriberValidator_Validates_Fields()
+        {
+            var v = new SubscriberValidator();
+            var invalid = new Subscriber();
+            var res = v.Validate(invalid);
+            Assert.Contains(res.Errors, e => e.PropertyName == nameof(Subscriber.Email));
+            Assert.Contains(res.Errors, e => e.PropertyName == nameof(Subscriber.Name));
+
+            var valid = new Subscriber { Email = "a@b.com", Name = "John" };
+            Assert.True(v.Validate(valid).IsValid);
+        }
+    }
+}


### PR DESCRIPTION
Add unit tests for various services and components

#### PR Classification
Addition of unit tests for various components and services in the BlazorBlog application.

#### PR Summary
This pull request introduces comprehensive unit tests to ensure the functionality and validation of various components and services within the BlazorBlog application. 
- **AllPostsPageTests.cs**: Added tests for rendering states and page number changes.
- **BlogPostDetailPageTests.cs**: Implemented tests for navigation and post display.
- **BlogPostAdminServiceForwardersTests.cs**: Added tests to verify method forwarding to the repository.
- **CategoryServiceTests.cs**: Introduced validation tests for category saving and slug generation.
- **ToastServiceAndExtensionsTests.cs**: Added tests for toast service functionality and duration handling.
