### PR TITLE
Add Docker and Compose support for BlazorBlog

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+**/bin/
+**/obj/
+**/TestResults/
+.vs/
+.vscode/
+.git/
+Dockerfile
+docker-compose.yml
+.env

--- a/.env
+++ b/.env
@@ -1,0 +1,3 @@
+POSTGRES_DB=blazorblog
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=postgres

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,40 @@
+# syntax=docker/dockerfile:1.6
+ARG DOTNET_VERSION=10.0
+
+# ---- Runtime (Linux) ----
+FROM mcr.microsoft.com/dotnet/aspnet:${DOTNET_VERSION}-alpine AS base
+WORKDIR /app
+EXPOSE 8080
+ENV ASPNETCORE_URLS=http://+:8080 \
+    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false
+RUN apk add --no-cache icu-libs
+
+# ---- Build ----
+FROM mcr.microsoft.com/dotnet/sdk:${DOTNET_VERSION}-alpine AS build
+WORKDIR /src
+
+# Install Node.js and npm only in the build image for Tailwind CSS.
+RUN apk add --no-cache nodejs npm
+
+# Copy project files first to keep restore layers cacheable.
+COPY BlazorBlog/BlazorBlog.csproj BlazorBlog/
+COPY BlazorBlog.Application/BlazorBlog.Application.csproj BlazorBlog.Application/
+COPY BlazorBlog.Domain/BlazorBlog.Domain.csproj BlazorBlog.Domain/
+COPY BlazorBlog.Infrastructure/BlazorBlog.Infrastructure.csproj BlazorBlog.Infrastructure/
+COPY BlazorBlog.Tests/BlazorBlog.Tests.csproj BlazorBlog.Tests/
+COPY BlazorBlog.sln ./
+
+# Restore for the Linux runtime target.
+RUN dotnet restore BlazorBlog.sln -r linux-x64
+
+# Copy the full source tree.
+COPY . .
+
+# Publish the web project. The project file builds Tailwind CSS during publish.
+RUN dotnet publish BlazorBlog/BlazorBlog.csproj -c Release -o /out -r linux-x64 --self-contained false /p:PublishTrimmed=false
+
+# ---- Final ----
+FROM base AS final
+WORKDIR /app
+COPY --from=build /out ./
+ENTRYPOINT ["dotnet", "BlazorBlog.dll"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,39 @@
+services:
+  db:
+    image: postgres:16
+    container_name: blazorblog-postgres
+    environment:
+      - POSTGRES_DB=${POSTGRES_DB:-blazorblog}
+      - POSTGRES_USER=${POSTGRES_USER:-postgres}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-postgres}
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-postgres} -d ${POSTGRES_DB:-blazorblog}"]
+      interval: 10s
+      timeout: 5s
+      retries: 30
+      start_period: 20s
+
+  web:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: unrealbg/blazorblog:latest
+    environment:
+      - ASPNETCORE_ENVIRONMENT=Production
+      - ConnectionStrings__DefaultConnection=Host=db;Port=5432;Database=${POSTGRES_DB:-blazorblog};Username=${POSTGRES_USER:-postgres};Password=${POSTGRES_PASSWORD:-postgres}
+    depends_on:
+      db:
+        condition: service_healthy
+    ports:
+      - "8080:8080"
+    # Optional persistent log volume.
+    # volumes:
+    #   - blazorblog-logs:/app/Logs
+
+volumes:
+  postgres-data:
+  # blazorblog-logs:


### PR DESCRIPTION
Add Docker and Compose support for BlazorBlog

Introduce Dockerfile for multi-stage .NET/Node.js builds, .dockerignore for build artifacts, and docker-compose.yml to orchestrate app with PostgreSQL. Add .env for environment variables.