### PR TITLE
Add BlazorBlog.AppHost project with Aspire and PostgreSQL

### DIFF
--- a/BlazorBlog.AppHost/BlazorBlog.AppHost.csproj
+++ b/BlazorBlog.AppHost/BlazorBlog.AppHost.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Aspire.AppHost.Sdk/13.3.3">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <UserSecretsId>blazorblog-apphost</UserSecretsId>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Aspire.Hosting.PostgreSQL" Version="13.3.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\BlazorBlog\BlazorBlog.csproj" />
+  </ItemGroup>
+</Project>

--- a/BlazorBlog.AppHost/Program.cs
+++ b/BlazorBlog.AppHost/Program.cs
@@ -1,0 +1,14 @@
+var builder = DistributedApplication.CreateBuilder(args);
+
+var postgres = builder.AddPostgres("postgres")
+    .WithDataVolume("blazorblog-postgres-data");
+
+var database = postgres.AddDatabase("DefaultConnection", "blazorblog");
+
+builder.AddProject<Projects.BlazorBlog>("web")
+    .WithReference(database)
+    .WaitFor(database)
+    .WithExternalHttpEndpoints()
+    .WithHttpHealthCheck("/health");
+
+builder.Build().Run();

--- a/BlazorBlog.AppHost/Properties/launchSettings.json
+++ b/BlazorBlog.AppHost/Properties/launchSettings.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "http://localhost:15053",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
+        "ASPNETCORE_URLS": "http://localhost:15053",
+        "ASPIRE_ALLOW_UNSECURED_TRANSPORT": "true",
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:21053",
+        "ASPIRE_DASHBOARD_OTLP_HTTP_ENDPOINT_URL": "http://localhost:21054",
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:22053"
+      }
+    }
+  }
+}

--- a/BlazorBlog.sln
+++ b/BlazorBlog.sln
@@ -13,6 +13,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BlazorBlog.Infrastructure",
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BlazorBlog.Tests", "BlazorBlog.Tests\BlazorBlog.Tests.csproj", "{B1C3D7E1-0000-0000-0000-000000000000}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BlazorBlog.AppHost", "BlazorBlog.AppHost\BlazorBlog.AppHost.csproj", "{9E40B453-AE7C-4C96-ABAC-CAB93EB63AF2}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -83,6 +85,18 @@ Global
 		{B1C3D7E1-0000-0000-0000-000000000000}.Release|x64.Build.0 = Release|Any CPU
 		{B1C3D7E1-0000-0000-0000-000000000000}.Release|x86.ActiveCfg = Release|Any CPU
 		{B1C3D7E1-0000-0000-0000-000000000000}.Release|x86.Build.0 = Release|Any CPU
+		{9E40B453-AE7C-4C96-ABAC-CAB93EB63AF2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9E40B453-AE7C-4C96-ABAC-CAB93EB63AF2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9E40B453-AE7C-4C96-ABAC-CAB93EB63AF2}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{9E40B453-AE7C-4C96-ABAC-CAB93EB63AF2}.Debug|x64.Build.0 = Debug|Any CPU
+		{9E40B453-AE7C-4C96-ABAC-CAB93EB63AF2}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{9E40B453-AE7C-4C96-ABAC-CAB93EB63AF2}.Debug|x86.Build.0 = Debug|Any CPU
+		{9E40B453-AE7C-4C96-ABAC-CAB93EB63AF2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9E40B453-AE7C-4C96-ABAC-CAB93EB63AF2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9E40B453-AE7C-4C96-ABAC-CAB93EB63AF2}.Release|x64.ActiveCfg = Release|Any CPU
+		{9E40B453-AE7C-4C96-ABAC-CAB93EB63AF2}.Release|x64.Build.0 = Release|Any CPU
+		{9E40B453-AE7C-4C96-ABAC-CAB93EB63AF2}.Release|x86.ActiveCfg = Release|Any CPU
+		{9E40B453-AE7C-4C96-ABAC-CAB93EB63AF2}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ COPY BlazorBlog.Application/BlazorBlog.Application.csproj BlazorBlog.Application
 COPY BlazorBlog.Domain/BlazorBlog.Domain.csproj BlazorBlog.Domain/
 COPY BlazorBlog.Infrastructure/BlazorBlog.Infrastructure.csproj BlazorBlog.Infrastructure/
 COPY BlazorBlog.Tests/BlazorBlog.Tests.csproj BlazorBlog.Tests/
+COPY BlazorBlog.AppHost/BlazorBlog.AppHost.csproj BlazorBlog.AppHost/
 COPY BlazorBlog.sln ./
 
 # Restore for the Linux runtime target.


### PR DESCRIPTION
Add BlazorBlog.AppHost project with Aspire and PostgreSQL

Introduced BlazorBlog.AppHost using Aspire.AppHost.Sdk targeting .NET 10.0. Configured distributed app hosting with PostgreSQL and health checks. Updated solution and Dockerfile to include the new AppHost project.