### PR TITLE
Add health checks and improve static asset caching

### DIFF
--- a/BlazorBlog/Components/App.razor
+++ b/BlazorBlog/Components/App.razor
@@ -27,8 +27,8 @@
     </script>
 
     <!-- Load component styles first -->
-    <link rel="stylesheet" href="BlazorBlog.styles.css" />
-    <link rel="stylesheet" href="app.css" />
+    <link rel="stylesheet" href="@Assets["BlazorBlog.styles.css"]" />
+    <link rel="stylesheet" href="@Assets["app.css"]" />
 
         <!-- Inter font -->
         <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -38,7 +38,7 @@
             html { font-family: Inter, ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, "Apple Color Emoji", "Segoe UI Emoji"; }
         </style>
 
-    <link rel="icon" type="image/png" href="favicon.png" />
+    <link rel="icon" type="image/png" href="@Assets["favicon.png"]" />
 
     <HeadOutlet />
 </head>
@@ -50,12 +50,12 @@
         </div>
     </CascadingAuthenticationState>
     <!-- Theme helpers (menu/theme toggles) -->
-    <script src="assets/js/functions.js" type="text/javascript"></script>
+    <script src="@Assets["assets/js/functions.js"]" type="text/javascript"></script>
 
     <SectionOutlet SectionName="scripts" />
 
     <!-- Blazor Scripts -->
-    <script src="_framework/blazor.web.js"></script>
+    <script src="@Assets["_framework/blazor.web.js"]"></script>
 </body>
 
 </html>

--- a/BlazorBlog/Components/Pages/Admin/SaveBlogPost.razor
+++ b/BlazorBlog/Components/Pages/Admin/SaveBlogPost.razor
@@ -13,7 +13,7 @@
 
 <SectionContent SectionName="scripts">
     <script src="https://cdn.jsdelivr.net/npm/quill@2.0.3/dist/quill.js"></script>
-    <script src="/assets/js/quill-editor.js"></script>
+    <script src="@Assets["assets/js/quill-editor.js"]"></script>
 </SectionContent>
 
 <AdminHeader Title="@PageTitle">

--- a/BlazorBlog/Health/DatabaseHealthCheck.cs
+++ b/BlazorBlog/Health/DatabaseHealthCheck.cs
@@ -1,0 +1,35 @@
+namespace BlazorBlog.Health
+{
+    using BlazorBlog.Infrastructure.Persistence;
+    using Microsoft.EntityFrameworkCore;
+    using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+    public sealed class DatabaseHealthCheck : IHealthCheck
+    {
+        private readonly IDbContextFactory<ApplicationDbContext> _contextFactory;
+
+        public DatabaseHealthCheck(IDbContextFactory<ApplicationDbContext> contextFactory)
+        {
+            _contextFactory = contextFactory;
+        }
+
+        public async Task<HealthCheckResult> CheckHealthAsync(
+            HealthCheckContext context,
+            CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                await using var db = await _contextFactory.CreateDbContextAsync(cancellationToken);
+                var canConnect = await db.Database.CanConnectAsync(cancellationToken);
+
+                return canConnect
+                    ? HealthCheckResult.Healthy("Database connection is available.")
+                    : HealthCheckResult.Unhealthy("Database connection is not available.");
+            }
+            catch (Exception ex)
+            {
+                return HealthCheckResult.Unhealthy("Database connection check failed.", ex);
+            }
+        }
+    }
+}

--- a/BlazorBlog/Health/DiskSpaceHealthCheck.cs
+++ b/BlazorBlog/Health/DiskSpaceHealthCheck.cs
@@ -1,0 +1,60 @@
+namespace BlazorBlog.Health
+{
+    using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+    public sealed class DiskSpaceHealthCheck : IHealthCheck
+    {
+        private const long DefaultMinimumFreeBytes = 100L * 1024L * 1024L;
+
+        private readonly IConfiguration _configuration;
+        private readonly IWebHostEnvironment _environment;
+
+        public DiskSpaceHealthCheck(IConfiguration configuration, IWebHostEnvironment environment)
+        {
+            _configuration = configuration;
+            _environment = environment;
+        }
+
+        public Task<HealthCheckResult> CheckHealthAsync(
+            HealthCheckContext context,
+            CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                var contentRoot = Path.GetFullPath(_environment.ContentRootPath);
+                var rootPath = Path.GetPathRoot(contentRoot);
+
+                if (string.IsNullOrWhiteSpace(rootPath))
+                {
+                    return Task.FromResult(HealthCheckResult.Unhealthy("Unable to resolve the content root drive."));
+                }
+
+                var drive = new DriveInfo(rootPath);
+                if (!drive.IsReady)
+                {
+                    return Task.FromResult(HealthCheckResult.Unhealthy("The content root drive is not ready."));
+                }
+
+                var minimumFreeBytes = _configuration.GetValue<long?>("HealthChecks:MinimumFreeDiskBytes")
+                    ?? DefaultMinimumFreeBytes;
+
+                var data = new Dictionary<string, object>
+                {
+                    ["path"] = contentRoot,
+                    ["drive"] = drive.Name,
+                    ["availableFreeBytes"] = drive.AvailableFreeSpace,
+                    ["minimumFreeBytes"] = minimumFreeBytes
+                };
+
+                return Task.FromResult(
+                    drive.AvailableFreeSpace >= minimumFreeBytes
+                        ? HealthCheckResult.Healthy("Disk space is sufficient.", data)
+                        : HealthCheckResult.Unhealthy("Available disk space is below the configured threshold.", data: data));
+            }
+            catch (Exception ex)
+            {
+                return Task.FromResult(HealthCheckResult.Unhealthy("Disk space check failed.", ex));
+            }
+        }
+    }
+}

--- a/BlazorBlog/Program.cs
+++ b/BlazorBlog/Program.cs
@@ -1,15 +1,20 @@
 namespace BlazorBlog
 {
     using System.Net;
+    using System.Text.Json;
 
     using Components.Account;
+    using BlazorBlog.Health;
     using BlazorBlog.Infrastructure;
     using BlazorBlog.Infrastructure.Settings;
     using Ganss.Xss;
+    using Microsoft.AspNetCore.Diagnostics.HealthChecks;
     using Microsoft.AspNetCore.Identity;
     using Microsoft.EntityFrameworkCore;
     using BlazorBlog.Application;
     using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Diagnostics.HealthChecks;
+    using Microsoft.AspNetCore.StaticFiles;
     using Serilog;
     using BlazorBlog.Infrastructure.Persistence;
 
@@ -58,6 +63,10 @@ namespace BlazorBlog
 
             builder.Services.AddSingleton<IHtmlSanitizer, HtmlSanitizer>(_ => new HtmlSanitizer());
 
+            builder.Services.AddHealthChecks()
+                .AddCheck<DatabaseHealthCheck>("database", tags: ["ready"])
+                .AddCheck<DiskSpaceHealthCheck>("disk", tags: ["ready"]);
+
             ValidateStartupConfiguration(builder);
 
             var app = builder.Build();
@@ -86,19 +95,123 @@ namespace BlazorBlog
             }
 
             app.UseHttpsRedirection();
-            app.UseStaticFiles();
+            app.Use(ApplyStaticAssetCacheHeaders);
+            app.UseStaticFiles(new StaticFileOptions
+            {
+                OnPrepareResponse = ConfigureStaticFileCacheHeaders
+            });
             app.UseAntiforgery();
+
+            app.MapStaticAssets();
 
             app.MapRazorComponents<App>()
                 .AddInteractiveServerRenderMode();
 
             app.MapAdditionalIdentityEndpoints();
 
-            // Lightweight health endpoint
-            app.MapGet("/health", () => Results.Ok(new { status = "ok", timeUtc = DateTime.UtcNow }))
-                .WithName("Health");
+            app.MapGet("/health", (ILogger<Program> logger) =>
+                {
+                    logger.LogDebug("Liveness health check completed.");
+                    return Results.Ok(new { status = "ok", timeUtc = DateTime.UtcNow });
+                })
+                .WithName("Health")
+                .WithTags("Health");
+
+            app.MapHealthChecks("/ready", new HealthCheckOptions
+            {
+                Predicate = check => check.Tags.Contains("ready", StringComparer.OrdinalIgnoreCase),
+                ResponseWriter = WriteHealthCheckResponseAsync
+            })
+                .WithName("Ready")
+                .WithTags("Health");
 
             app.Run();
+
+            static Task WriteHealthCheckResponseAsync(HttpContext context, HealthReport report)
+            {
+                var logger = context.RequestServices.GetRequiredService<ILogger<Program>>();
+                var logLevel = report.Status == HealthStatus.Healthy ? LogLevel.Information : LogLevel.Warning;
+
+                logger.Log(
+                    logLevel,
+                    "Readiness health check completed with status {Status} in {ElapsedMilliseconds} ms.",
+                    report.Status,
+                    report.TotalDuration.TotalMilliseconds);
+
+                context.Response.ContentType = "application/json";
+
+                var response = new
+                {
+                    status = report.Status.ToString(),
+                    timeUtc = DateTime.UtcNow,
+                    totalDurationMilliseconds = Math.Round(report.TotalDuration.TotalMilliseconds, 2),
+                    checks = report.Entries.ToDictionary(
+                        entry => entry.Key,
+                        entry => new
+                        {
+                            status = entry.Value.Status.ToString(),
+                            entry.Value.Description,
+                            durationMilliseconds = Math.Round(entry.Value.Duration.TotalMilliseconds, 2),
+                            entry.Value.Data
+                        })
+                };
+
+                return context.Response.WriteAsJsonAsync(response, new JsonSerializerOptions(JsonSerializerDefaults.Web));
+            }
+
+            static async Task ApplyStaticAssetCacheHeaders(HttpContext context, RequestDelegate next)
+            {
+                var path = context.Request.Path.Value ?? string.Empty;
+
+                if (IsLongLivedAsset(path))
+                {
+                    var environment = context.RequestServices.GetRequiredService<IWebHostEnvironment>();
+
+                    context.Response.OnStarting(() =>
+                    {
+                        if (!context.Response.Headers.ContainsKey("Cache-Control"))
+                        {
+                            context.Response.Headers.CacheControl = environment.IsDevelopment()
+                                ? "no-cache"
+                                : "public,max-age=31536000,immutable";
+                        }
+
+                        return Task.CompletedTask;
+                    });
+                }
+
+                await next(context);
+            }
+
+            static void ConfigureStaticFileCacheHeaders(StaticFileResponseContext context)
+            {
+                var environment = context.Context.RequestServices.GetRequiredService<IWebHostEnvironment>();
+                var path = context.Context.Request.Path.Value ?? string.Empty;
+
+                context.Context.Response.Headers.CacheControl = environment.IsDevelopment()
+                    ? "no-cache"
+                    : IsLongLivedAsset(path)
+                        ? "public,max-age=31536000,immutable"
+                        : "public,max-age=3600";
+            }
+
+            static bool IsLongLivedAsset(string path)
+            {
+                var extension = Path.GetExtension(path);
+
+                return extension.Equals(".css", StringComparison.OrdinalIgnoreCase) ||
+                    extension.Equals(".js", StringComparison.OrdinalIgnoreCase) ||
+                    extension.Equals(".png", StringComparison.OrdinalIgnoreCase) ||
+                    extension.Equals(".jpg", StringComparison.OrdinalIgnoreCase) ||
+                    extension.Equals(".jpeg", StringComparison.OrdinalIgnoreCase) ||
+                    extension.Equals(".gif", StringComparison.OrdinalIgnoreCase) ||
+                    extension.Equals(".svg", StringComparison.OrdinalIgnoreCase) ||
+                    extension.Equals(".webp", StringComparison.OrdinalIgnoreCase) ||
+                    extension.Equals(".avif", StringComparison.OrdinalIgnoreCase) ||
+                    extension.Equals(".ico", StringComparison.OrdinalIgnoreCase) ||
+                    extension.Equals(".woff", StringComparison.OrdinalIgnoreCase) ||
+                    extension.Equals(".woff2", StringComparison.OrdinalIgnoreCase);
+            }
 
             static async Task ApplyMigrationsAsync(IServiceProvider services)
             {

--- a/BlazorBlog/appsettings.json
+++ b/BlazorBlog/appsettings.json
@@ -37,5 +37,8 @@
     "Password": "Admin@123",
     "Role": "Admin"
   },
+  "HealthChecks": {
+    "MinimumFreeDiskBytes": 104857600
+  },
   "AllowedHosts": "*"
 }


### PR DESCRIPTION
Add health checks and improve static asset caching

Introduce database and disk space health checks with a new /ready endpoint for readiness probes. Enhance static asset handling by using the Assets dictionary for URLs and applying environment-aware cache-control headers. Add disk space threshold configuration to appsettings.json.