### PR TITLE
Update .dockerignore and package references visibility

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,8 @@
 **/bin/
 **/obj/
+**/node_modules/
 **/TestResults/
+**/Logs/
 .vs/
 .vscode/
 .git/

--- a/BlazorBlog/BlazorBlog.csproj
+++ b/BlazorBlog/BlazorBlog.csproj
@@ -8,12 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="HtmlSanitizer" Version="9.0.892">
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="AngleSharp.Css" Version="0.17.0">
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
+    <PackageReference Include="HtmlSanitizer" Version="9.0.892" />
+    <PackageReference Include="AngleSharp.Css" Version="0.17.0" />
     <PackageReference Include="Microsoft.AspNetCore.Components.QuickGrid" Version="10.0.8" />
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="10.0.8" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.8">


### PR DESCRIPTION
Update .dockerignore and package references visibility

Updated .dockerignore to exclude node_modules and Logs directories. Removed <PrivateAssets>all</PrivateAssets> from HtmlSanitizer and AngleSharp.Css in BlazorBlog.csproj to make them available to referencing projects.