### PR TITLE
Remove authorization checks from Dashboard.razor

### DIFF
--- a/BlazorBlog/Components/Pages/Admin/Dashboard.razor
+++ b/BlazorBlog/Components/Pages/Admin/Dashboard.razor
@@ -12,22 +12,15 @@
 <AdminHeader Title="Dashboard" />
 
 <div class="space-y-6">
-    <AuthorizeView Policy="RequireAdminRole">
- <Authorized>
- <div class="rounded-xl border border-slate-200/60 bg-white p-5 shadow-soft dark:border-slate-800 dark:bg-slate-900">
-  <div class="flex items-start justify-between gap-4">
+    <div class="rounded-xl border border-slate-200/60 bg-white p-5 shadow-soft dark:border-slate-800 dark:bg-slate-900">
+        <div class="flex items-start justify-between gap-4">
             <div>
-       <h2 class="text-base font-semibold text-slate-900 dark:text-slate-100">Welcome, @context.User.GetUserName()</h2>
-            <p class="mt-1 text-sm text-slate-600 dark:text-slate-300">You are logged in as an administrator.</p>
+                <h2 class="text-base font-semibold text-slate-900 dark:text-slate-100">Welcome to the admin dashboard</h2>
+                <p class="mt-1 text-sm text-slate-600 dark:text-slate-300">You are logged in as an administrator.</p>
+            </div>
+            <span class="inline-flex items-center rounded-full bg-brand-50 px-2 py-1 text-xs font-medium text-brand-700 ring-1 ring-inset ring-brand-600/20 dark:bg-brand-600/15 dark:text-brand-300">Admin</span>
         </div>
-     <span class="inline-flex items-center rounded-full bg-brand-50 px-2 py-1 text-xs font-medium text-brand-700 ring-1 ring-inset ring-brand-600/20 dark:bg-brand-600/15 dark:text-brand-300">Admin</span>
-     </div>
-     </div>
-        </Authorized>
-        <NotAuthorized>
-         <UnauthorizedAccess RequiredRole="Admin" />
-   </NotAuthorized>
-    </AuthorizeView>
+    </div>
 
     <section class="pt-1">
         <h3 class="mb-3 text-sm font-semibold text-slate-700 dark:text-slate-200">Quick actions</h3>


### PR DESCRIPTION
Remove authorization checks from Dashboard.razor

Dashboard now renders for all users without <AuthorizeView>.
Replaced personalized welcome with a generic message.
Reorganized markup and moved "Admin" badge for clarity.