### PR TITLE
Remove [DoesNotReturn] and update redirect logic

### DIFF
--- a/BlazorBlog/Components/Account/IdentityRedirectManager.cs
+++ b/BlazorBlog/Components/Account/IdentityRedirectManager.cs
@@ -1,7 +1,5 @@
 namespace BlazorBlog.Components.Account
 {
-    using System.Diagnostics.CodeAnalysis;
-
     internal sealed class IdentityRedirectManager(NavigationManager navigationManager)
     {
         public const string StatusCookieName = "Identity.StatusMessage";
@@ -14,7 +12,6 @@ namespace BlazorBlog.Components.Account
             MaxAge = TimeSpan.FromSeconds(5),
         };
 
-        [DoesNotReturn]
         public void RedirectTo(string? uri)
         {
             uri ??= "";
@@ -25,13 +22,11 @@ namespace BlazorBlog.Components.Account
                 uri = navigationManager.ToBaseRelativePath(uri);
             }
 
-            // During static rendering, NavigateTo throws a NavigationException which is handled by the framework as a redirect.
-            // So as long as this is called from a statically rendered Identity component, the InvalidOperationException is never thrown.
+            // In .NET 10 static SSR, NavigateTo can complete without throwing. Let the
+            // framework finish the redirect instead of throwing after a successful login.
             navigationManager.NavigateTo(uri);
-            throw new InvalidOperationException($"{nameof(IdentityRedirectManager)} can only be used during static rendering.");
         }
 
-        [DoesNotReturn]
         public void RedirectTo(string uri, Dictionary<string, object?> queryParameters)
         {
             var uriWithoutQuery = navigationManager.ToAbsoluteUri(uri).GetLeftPart(UriPartial.Path);
@@ -39,7 +34,6 @@ namespace BlazorBlog.Components.Account
             RedirectTo(newUri);
         }
 
-        [DoesNotReturn]
         public void RedirectToWithStatus(string uri, string message, HttpContext context)
         {
             context.Response.Cookies.Append(StatusCookieName, message, StatusCookieBuilder.Build(context));
@@ -48,10 +42,8 @@ namespace BlazorBlog.Components.Account
 
         private string CurrentPath => navigationManager.ToAbsoluteUri(navigationManager.Uri).GetLeftPart(UriPartial.Path);
 
-        [DoesNotReturn]
         public void RedirectToCurrentPage() => RedirectTo(CurrentPath);
 
-        [DoesNotReturn]
         public void RedirectToCurrentPageWithStatus(string message, HttpContext context)
             => RedirectToWithStatus(CurrentPath, message, context);
     }

--- a/BlazorBlog/Components/Account/IdentityUserAccessor.cs
+++ b/BlazorBlog/Components/Account/IdentityUserAccessor.cs
@@ -13,6 +13,7 @@ namespace BlazorBlog.Components.Account
             if (user is null)
             {
                 redirectManager.RedirectToWithStatus("Account/InvalidUser", $"Error: Unable to load user with ID '{userManager.GetUserId(context.User)}'.", context);
+                return null!;
             }
 
             return user;


### PR DESCRIPTION
Remove [DoesNotReturn] and update redirect logic

Removed [DoesNotReturn] from redirect methods in IdentityRedirectManager and stopped throwing after NavigateTo to support .NET 10 static SSR. Also, ensure null! is returned after redirect in IdentityUserAccessor when user is not found.