### PR TITLE
Add dual-mode (WYSIWYG/Markdown) blog post editor

### DIFF
--- a/BlazorBlog.Tests/Component/BlogPostDetailPageTests.cs
+++ b/BlazorBlog.Tests/Component/BlogPostDetailPageTests.cs
@@ -12,6 +12,7 @@ namespace BlazorBlog.Tests.Component
     using BlazorBlog.Application.Models;
     using FluentValidation;
     using BlazorBlog.Infrastructure.Contracts;
+    using Ganss.Xss;
 
     public class BlogPostDetailPageTests
     {
@@ -23,6 +24,7 @@ namespace BlazorBlog.Tests.Component
             blog.Setup(s => s.GetBlogPostBySlugAsync("missing", It.IsAny<CancellationToken>()))
                 .ReturnsAsync(DetailPageModel.Empty());
             ctx.Services.AddSingleton(blog.Object);
+            ctx.Services.AddSingleton<IHtmlSanitizer, HtmlSanitizer>();
 
             var nav = ctx.Services.GetRequiredService<NavigationManager>();
             var cut = ctx.Render<BlogPostDetail>(p => p.Add(x => x.BlogPostSlug, "missing"));
@@ -49,6 +51,7 @@ namespace BlazorBlog.Tests.Component
                 .ReturnsAsync(System.Array.Empty<BlogPostVm>());
 
             ctx.Services.AddSingleton(blog.Object);
+            ctx.Services.AddSingleton<IHtmlSanitizer, HtmlSanitizer>();
             // Register DI required by SubscribeBox
             ctx.Services.AddSingleton<ISubscribeService, BlazorBlog.Tests.Component.DummySubscribeService>();
             ctx.Services.AddScoped<IValidator<BlazorBlog.Domain.Entities.Subscriber>, BlazorBlog.Tests.Component.DummySubscriberValidator>();

--- a/BlazorBlog/BlazorBlog.csproj
+++ b/BlazorBlog/BlazorBlog.csproj
@@ -10,6 +10,7 @@
   <ItemGroup>
     <PackageReference Include="HtmlSanitizer" Version="9.0.892" />
     <PackageReference Include="AngleSharp.Css" Version="0.17.0" />
+    <PackageReference Include="Markdig" Version="1.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Components.QuickGrid" Version="10.0.8" />
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="10.0.8" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.8">

--- a/BlazorBlog/Components/Pages/Admin/SaveBlogPost.razor
+++ b/BlazorBlog/Components/Pages/Admin/SaveBlogPost.razor
@@ -95,35 +95,65 @@
         </div>
         <div class="lg:col-span-6">
             <div class="mb-4">
-                <label class="mb-1 block text-sm font-medium text-slate-700 dark:text-slate-200">Content <span class="text-red-600">*</span></label>
-                <div id="@_toolbarId">
-                    <select class="ql-header">
-                        <option selected=""></option>
-                        <option value="1"></option>
-                        <option value="2"></option>
-                        <option value="3"></option>
-                        <option value="4"></option>
-                        <option value="5"></option>
-                    </select>
-                    <span class="ql-formats">
-                        <button class="ql-bold"></button>
-                        <button class="ql-italic"></button>
-                        <button class="ql-underline"></button>
-                        <button class="ql-strike"></button>
-                    </span>
-                    <span class="ql-formats">
-                        <button class="ql-color"></button>
-                        <button class="ql-background"></button>
-                    </span>
-                    <span class="ql-formats">
-                        <button class="ql-list" value="ordered"></button>
-                        <button class="ql-list" value="bullet"></button>
-                    </span>
-                    <span class="ql-formats">
-                        <button class="ql-link"></button>
-                    </span>
+                <div class="mb-2 flex flex-wrap items-center justify-between gap-3">
+                    <label class="block text-sm font-medium text-slate-700 dark:text-slate-200">Content <span class="text-red-600">*</span></label>
+                    <div class="inline-flex rounded-md border border-slate-300 bg-white p-0.5 text-sm shadow-sm dark:border-slate-700 dark:bg-slate-900">
+                        <button type="button"
+                                class="@GetEditorModeButtonClass(ContentEditorMode.Visual)"
+                                @onclick="() => SetEditorModeAsync(ContentEditorMode.Visual)">
+                            Visual
+                        </button>
+                        <button type="button"
+                                class="@GetEditorModeButtonClass(ContentEditorMode.Source)"
+                                @onclick="() => SetEditorModeAsync(ContentEditorMode.Source)">
+                            Markdown / HTML
+                        </button>
+                    </div>
                 </div>
-                <div id="@_editorId" class="min-h-72 bg-white dark:bg-slate-900"></div>
+                <div class="@(_editorMode == ContentEditorMode.Visual ? null : "hidden")">
+                    <div id="@_toolbarId">
+                        <select class="ql-header">
+                            <option selected=""></option>
+                            <option value="1"></option>
+                            <option value="2"></option>
+                            <option value="3"></option>
+                            <option value="4"></option>
+                            <option value="5"></option>
+                        </select>
+                        <span class="ql-formats">
+                            <button class="ql-bold"></button>
+                            <button class="ql-italic"></button>
+                            <button class="ql-underline"></button>
+                            <button class="ql-strike"></button>
+                        </span>
+                        <span class="ql-formats">
+                            <button class="ql-color"></button>
+                            <button class="ql-background"></button>
+                        </span>
+                        <span class="ql-formats">
+                            <button class="ql-list" value="ordered"></button>
+                            <button class="ql-list" value="bullet"></button>
+                        </span>
+                        <span class="ql-formats">
+                            <button class="ql-link"></button>
+                        </span>
+                    </div>
+                    <div id="@_editorId" class="min-h-72 bg-white dark:bg-slate-900"></div>
+                </div>
+                <div class="@(_editorMode == ContentEditorMode.Source ? "space-y-4" : "hidden")">
+                    <textarea @bind="_sourceContent"
+                              @bind:event="oninput"
+                              class="min-h-72 w-full resize-y rounded-md border border-slate-300 bg-white px-3 py-2 font-mono text-sm text-slate-900 shadow-sm focus:border-brand-500 focus:outline-none focus:ring-1 focus:ring-brand-500 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100"
+                              placeholder="# Heading&#10;&#10;Write Markdown or HTML here..."></textarea>
+                    <div>
+                        <div class="mb-2 text-sm font-medium text-slate-700 dark:text-slate-200">Preview</div>
+                        <div class="min-h-48 rounded-md border border-slate-200 bg-white p-4 dark:border-slate-800 dark:bg-slate-900">
+                            <div class="prose prose-slate max-w-none dark:prose-invert">
+                                @((MarkupString)PreviewContent)
+                            </div>
+                        </div>
+                    </div>
+                </div>
                 <ValidationMessage For="() => _blogPostVm.Content" class="mt-1 block text-sm text-red-600" />
             </div>
         </div>

--- a/BlazorBlog/Components/Pages/Admin/SaveBlogPost.razor.cs
+++ b/BlazorBlog/Components/Pages/Admin/SaveBlogPost.razor.cs
@@ -2,6 +2,7 @@
 {
     using Microsoft.AspNetCore.Components.Forms;
     using Microsoft.JSInterop;
+    using BlazorBlog.Utilities;
     using Category = BlazorBlog.Domain.Entities.Category;
     using BlogPost = BlazorBlog.Domain.Entities.BlogPost;
 
@@ -28,14 +29,23 @@
         private string? _errorMessage = null;
         private IBrowserFile? _fileToUpload;
         private string? _imageUrl;
+        private string _sourceContent = string.Empty;
+        private ContentEditorMode _editorMode = ContentEditorMode.Visual;
         private string PageTitle => Id is > 0 ? "Edit Blog Post" : "New Blog Post";
         private bool _isSaving;
         private readonly string _editorId = $"blog-post-editor-{Guid.NewGuid():N}";
         private readonly string _toolbarId = $"blog-post-toolbar-{Guid.NewGuid():N}";
         public bool IsSaving => _isSaving;
         public string TagsCsv { get; set; } = string.Empty;
+        private string PreviewContent => BlogContentRenderer.RenderSafeHtml(_sourceContent, HtmlSanitizer);
 
         private readonly CancellationTokenSource _cts = new();
+
+        private enum ContentEditorMode
+        {
+            Visual,
+            Source
+        }
 
         [Inject] AuthenticationStateProvider AuthenticationStateProvider { get; set; } = default!;
         [Inject] IWebHostEnvironment WebHostEnvironment { get; set; } = default!;
@@ -74,6 +84,7 @@
                 _messageStore = new ValidationMessageStore(_editContext);
                 _imageUrl = blogPost.Image;
                 _content = blogPost.Content;
+                _sourceContent = blogPost.Content;
 
                 try
                 {
@@ -84,6 +95,35 @@
             }
             _isLoading = false;
             _loadingText = null;
+        }
+
+        private async Task SetEditorModeAsync(ContentEditorMode mode)
+        {
+            if (_editorMode == mode)
+            {
+                return;
+            }
+
+            if (mode == ContentEditorMode.Source)
+            {
+                _sourceContent = await JsRuntime.InvokeAsync<string>("blazorBlogQuill.getHtml", _editorId);
+            }
+            else
+            {
+                var safeHtml = BlogContentRenderer.RenderSafeHtml(_sourceContent, HtmlSanitizer);
+                await JsRuntime.InvokeVoidAsync("blazorBlogQuill.setHtml", _editorId, safeHtml);
+            }
+
+            _editorMode = mode;
+        }
+
+        private string GetEditorModeButtonClass(ContentEditorMode mode)
+        {
+            var active = _editorMode == mode
+                ? "bg-brand-600 text-white shadow-sm"
+                : "text-slate-700 hover:bg-slate-100 dark:text-slate-300 dark:hover:bg-slate-800";
+
+            return $"rounded px-3 py-1.5 font-medium transition {active}";
         }
 
         protected override async Task OnAfterRenderAsync(bool firstRender)
@@ -138,17 +178,34 @@
         {
             _messageStore!.Clear();
 
-            var plain = (await JsRuntime.InvokeAsync<string>("blazorBlogQuill.getText", _editorId))?.Trim();
-            if (string.IsNullOrWhiteSpace(plain))
+            if (_editorMode == ContentEditorMode.Source)
             {
-                var fi = new FieldIdentifier(_blogPostVm, nameof(_blogPostVm.Content));
-                _messageStore.Add(fi, "The content is required.");
-                _editContext.NotifyValidationStateChanged();
-                return;
+                if (string.IsNullOrWhiteSpace(_sourceContent))
+                {
+                    AddContentValidationError("The content is required.");
+                    return;
+                }
+
+                _blogPostVm.Content = BlogContentRenderer.RenderSafeHtml(_sourceContent, HtmlSanitizer);
+            }
+            else
+            {
+                var plain = (await JsRuntime.InvokeAsync<string>("blazorBlogQuill.getText", _editorId))?.Trim();
+                if (string.IsNullOrWhiteSpace(plain))
+                {
+                    AddContentValidationError("The content is required.");
+                    return;
+                }
+
+                var html = await JsRuntime.InvokeAsync<string>("blazorBlogQuill.getHtml", _editorId);
+                _blogPostVm.Content = HtmlSanitizer.Sanitize(html);
             }
 
-            var html = await JsRuntime.InvokeAsync<string>("blazorBlogQuill.getHtml", _editorId);
-            _blogPostVm.Content = HtmlSanitizer.Sanitize(html);
+            if (string.IsNullOrWhiteSpace(_blogPostVm.Content))
+            {
+                AddContentValidationError("The content is required.");
+                return;
+            }
 
             var validationResult = await Validator.ValidateAsync(_blogPostVm, _cts.Token);
             if (!validationResult.IsValid)
@@ -167,6 +224,13 @@
             _loadingText = "Saving blog post...";
             StateHasChanged();
             await SaveBlogPostAsync();
+        }
+
+        private void AddContentValidationError(string message)
+        {
+            var fi = new FieldIdentifier(_blogPostVm, nameof(_blogPostVm.Content));
+            _messageStore!.Add(fi, message);
+            _editContext.NotifyValidationStateChanged();
         }
 
         private async Task SaveBlogPostAsync()

--- a/BlazorBlog/Components/Pages/BlogPostDetail.razor
+++ b/BlazorBlog/Components/Pages/BlogPostDetail.razor
@@ -69,7 +69,7 @@
                 }
 
                 <div id="post-body" class="prose prose-slate max-w-none dark:prose-invert">
-                    @((MarkupString)_blogPost.Content)
+                    @((MarkupString)_renderedContent)
                 </div>
 
                 <div class="mt-6 flex flex-wrap items-center gap-2">

--- a/BlazorBlog/Components/Pages/BlogPostDetail.razor.cs
+++ b/BlazorBlog/Components/Pages/BlogPostDetail.razor.cs
@@ -1,6 +1,7 @@
 ﻿namespace BlazorBlog.Components.Pages
 {
     using BlazorBlog.Application.Utilities;
+    using BlazorBlog.Utilities;
 
     public partial class BlogPostDetail
     {
@@ -12,6 +13,7 @@
         private string _authorName = string.Empty;
         private string _publishedAt = string.Empty;
         private string _readTime = string.Empty;
+        private string _renderedContent = string.Empty;
         private int _wordCount = 0;
 
         [Inject]
@@ -19,6 +21,9 @@
 
         [Inject]
         IBlogPostService BlogPostService { get; set; } = default!;
+
+        [Inject]
+        IHtmlSanitizer HtmlSanitizer { get; set; } = default!;
 
         [Parameter]
         public string BlogPostSlug { get; set; } = string.Empty;
@@ -42,6 +47,7 @@
             _categoryName = _blogPost.CategoryName ?? string.Empty;
             _authorName = _blogPost.AuthorName ?? string.Empty;
             _publishedAt = _blogPost.PublishedAtDisplay ?? string.Empty;
+            _renderedContent = BlogContentRenderer.RenderSafeHtml(_blogPost.Content, HtmlSanitizer);
 
             if (!string.IsNullOrWhiteSpace(_blogPost.ReadingTime))
             {

--- a/BlazorBlog/Utilities/BlogContentRenderer.cs
+++ b/BlazorBlog/Utilities/BlogContentRenderer.cs
@@ -1,0 +1,23 @@
+namespace BlazorBlog.Utilities
+{
+    using Ganss.Xss;
+    using Markdig;
+
+    public static class BlogContentRenderer
+    {
+        private static readonly MarkdownPipeline Pipeline = new MarkdownPipelineBuilder()
+            .UseAdvancedExtensions()
+            .Build();
+
+        public static string RenderSafeHtml(string content, IHtmlSanitizer sanitizer)
+        {
+            if (string.IsNullOrWhiteSpace(content))
+            {
+                return string.Empty;
+            }
+
+            var html = Markdown.ToHtml(content, Pipeline);
+            return sanitizer.Sanitize(html);
+        }
+    }
+}

--- a/BlazorBlog/wwwroot/assets/js/quill-editor.js
+++ b/BlazorBlog/wwwroot/assets/js/quill-editor.js
@@ -31,6 +31,18 @@
             return editor && editor.__quill ? editor.__quill.getText() : "";
         },
 
+        setHtml: function (editorId, html) {
+            const editor = document.getElementById(editorId);
+            if (!editor || !editor.__quill) {
+                return;
+            }
+
+            editor.__quill.setContents([]);
+            if (html) {
+                editor.__quill.clipboard.dangerouslyPasteHTML(html);
+            }
+        },
+
         dispose: function (editorId) {
             const editor = document.getElementById(editorId);
             if (editor) {


### PR DESCRIPTION
Add dual-mode (WYSIWYG/Markdown) blog post editor

Introduce a content editor with Visual and Source modes, including a toolbar for switching and live Markdown preview. Add BlogContentRenderer utility for Markdown-to-HTML conversion and sanitization. Update BlogPostDetail to render sanitized HTML. Extend quill-editor.js with setHtml. Add Markdig dependency and update DI for IHtmlSanitizer.