### PR TITLE
Add Site Settings card; remove Resources section from dashboard

### DIFF
--- a/BlazorBlog/Components/Pages/Admin/Dashboard.razor
+++ b/BlazorBlog/Components/Pages/Admin/Dashboard.razor
@@ -75,20 +75,23 @@
      </svg>
          </div>
             </a>
+            <a href="admin/site-settings" class="group rounded-xl border border-slate-200/60 bg-white p-4 shadow-soft transition hover:-translate-y-0.5 hover:shadow dark:border-slate-800 dark:bg-slate-900">
+                <div class="flex items-center justify-between gap-3">
+                    <span class="inline-grid h-10 w-10 place-items-center rounded-lg bg-gradient-to-tr from-brand-600 to-accent-500 text-white shadow-soft">
+                        <svg viewBox="0 0 24 24" width="18" height="18" fill="currentColor" aria-hidden="true"><path d="M19.4 13a7.5 7.5 0 000-2l2-1.5-2-3.4-2.4 1a7.4 7.4 0 00-1.7-1L15 3h-4l-.3 3.1a7.4 7.4 0 00-1.7 1l-2.4-1-2 3.4L6.6 11a7.5 7.5 0 000 2l-2 1.5 2 3.4 2.4-1a7.4 7.4 0 001.7 1L11 21h4l.3-3.1a7.4 7.4 0 001.7-1l2.4 1 2-3.4-2-1.5zM13 16a4 4 0 110-8 4 4 0 010 8z"/></svg>
+                    </span>
+                    <div class="min-w-0">
+                        <div class="font-medium text-slate-900 group-hover:text-brand-700 dark:text-slate-100">Site Settings</div>
+                        <p class="text-xs text-slate-500">Edit home copy and links.</p>
+                    </div>
+                    <svg class="h-5 w-5 text-slate-400 group-hover:text-brand-600" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                        <path d="M9 5l7 7-7 7"/>
+                    </svg>
+                </div>
+            </a>
         </div>
     </section>
 
-    <section>
-        <h3 class="mb-3 text-sm font-semibold text-slate-700 dark:text-slate-200">Resources</h3>
-        <div class="prose max-w-none prose-slate dark:prose-invert">
-    <ul>
-                <li>ASP.NET Core Blazor: <a href="https://docs.microsoft.com/aspnet/core/blazor" target="_blank" rel="noopener">docs</a> and <a href="https://dotnet.microsoft.com/apps/aspnet/web-apps/blazor" target="_blank" rel="noopener">overview</a>.</li>
-      <li>Authentication and authorization: <a href="https://docs.microsoft.com/aspnet/core/security/blazor" target="_blank" rel="noopener">Blazor security</a>.</li>
-        <li>SignalR realtime: <a href="https://docs.microsoft.com/aspnet/core/tutorials/signalr-blazor-webassembly" target="_blank" rel="noopener">tutorials</a>.</li>
-          <li>Testing: <a href="https://docs.microsoft.com/aspnet/core/test/integration-tests" target="_blank" rel="noopener">integration tests</a>.</li>
-      </ul>
-      </div>
- </section>
 </div>
 
 @code {


### PR DESCRIPTION
Add Site Settings card; remove Resources section from dashboard

Added a new navigation card for "Site Settings" to the dashboard, enabling editing of home copy and links. Removed the Resources section with external documentation links.