### PR TITLE
Add RSS feed endpoint with config and tests

### DIFF
--- a/BlazorBlog.Tests/Feeds/FeedEndpointExtensionsTests.cs
+++ b/BlazorBlog.Tests/Feeds/FeedEndpointExtensionsTests.cs
@@ -1,0 +1,37 @@
+namespace BlazorBlog.Tests.Feeds
+{
+    using System;
+    using BlazorBlog.Feeds;
+    using Xunit;
+
+    public class FeedEndpointExtensionsTests
+    {
+        [Fact]
+        public void BuildCacheKey_ChangesWhenSignalVersionChanges()
+        {
+            var baseUri = new Uri("https://example.com/");
+
+            var first = FeedEndpointExtensions.BuildCacheKey(baseUri, itemCount: 20, signalVersion: 1);
+            var second = FeedEndpointExtensions.BuildCacheKey(baseUri, itemCount: 20, signalVersion: 2);
+
+            Assert.NotEqual(first, second);
+        }
+
+        [Fact]
+        public void Normalize_ClampsConfigurableLimits()
+        {
+            var options = FeedEndpointExtensions.Normalize(new FeedOptions
+            {
+                Title = " ",
+                Description = "",
+                ItemCount = 500,
+                CacheMinutes = 0
+            });
+
+            Assert.Equal("Blazor Blog", options.Title);
+            Assert.Equal("Latest published posts from Blazor Blog.", options.Description);
+            Assert.Equal(100, options.ItemCount);
+            Assert.Equal(1, options.CacheMinutes);
+        }
+    }
+}

--- a/BlazorBlog.Tests/Feeds/RssFeedDocumentTests.cs
+++ b/BlazorBlog.Tests/Feeds/RssFeedDocumentTests.cs
@@ -1,0 +1,87 @@
+namespace BlazorBlog.Tests.Feeds
+{
+    using System;
+    using System.Linq;
+    using System.Xml.Linq;
+    using BlazorBlog.Application.Models;
+    using BlazorBlog.Feeds;
+    using Xunit;
+
+    public class RssFeedDocumentTests
+    {
+        [Fact]
+        public void Create_ProducesValidRssWithAbsoluteUrlsAndUtcDates()
+        {
+            var posts = new[]
+            {
+                new BlogPostVm
+                {
+                    Title = "Hello RSS",
+                    Slug = "hello-rss",
+                    Introduction = "Intro",
+                    Content = "<p>Safe content</p>",
+                    PublishedAt = new DateTime(2026, 5, 24, 10, 30, 0, DateTimeKind.Utc)
+                }
+            };
+
+            var xml = RssFeedDocument.Create(
+                posts,
+                new Uri("https://example.com/blog/"),
+                new Uri("https://example.com/blog/feed"),
+                new FeedOptions { Title = "Test Blog", Description = "Latest posts" },
+                summary => summary,
+                content => content);
+
+            var document = XDocument.Parse(xml);
+            XNamespace contentNamespace = "http://purl.org/rss/1.0/modules/content/";
+            XNamespace atomNamespace = "http://www.w3.org/2005/Atom";
+
+            Assert.Equal("rss", document.Root?.Name.LocalName);
+            Assert.Equal("2.0", document.Root?.Attribute("version")?.Value);
+
+            var channel = document.Root?.Element("channel");
+            Assert.NotNull(channel);
+            Assert.Equal("Test Blog", channel!.Element("title")?.Value);
+            Assert.Equal("https://example.com/blog/", channel.Element("link")?.Value);
+
+            var selfLink = channel.Elements(atomNamespace + "link").Single();
+            Assert.Equal("https://example.com/blog/feed", selfLink.Attribute("href")?.Value);
+
+            var item = channel.Elements("item").Single();
+            Assert.Equal("https://example.com/blog/posts/hello-rss", item.Element("link")?.Value);
+            Assert.Equal("Sun, 24 May 2026 10:30:00 GMT", item.Element("pubDate")?.Value);
+            Assert.Equal("<p>Safe content</p>", item.Element(contentNamespace + "encoded")?.Value);
+        }
+
+        [Fact]
+        public void Create_SanitizesSummaryAndContentThroughCallbacks()
+        {
+            var posts = new[]
+            {
+                new BlogPostVm
+                {
+                    Title = "Unsafe",
+                    Slug = "unsafe",
+                    Introduction = "<script>alert(1)</script>Summary",
+                    Content = "<script>alert(2)</script>Content",
+                    PublishedAt = DateTime.UtcNow
+                }
+            };
+
+            var xml = RssFeedDocument.Create(
+                posts,
+                new Uri("https://example.com/"),
+                new Uri("https://example.com/feed"),
+                new FeedOptions(),
+                summary => summary.Replace("<script>alert(1)</script>", string.Empty, StringComparison.Ordinal),
+                content => content.Replace("<script>alert(2)</script>", string.Empty, StringComparison.Ordinal));
+
+            var document = XDocument.Parse(xml);
+            XNamespace contentNamespace = "http://purl.org/rss/1.0/modules/content/";
+            var item = document.Root!.Element("channel")!.Element("item")!;
+
+            Assert.Equal("Summary", item.Element("description")?.Value);
+            Assert.Equal("Content", item.Element(contentNamespace + "encoded")?.Value);
+        }
+    }
+}

--- a/BlazorBlog/Feeds/FeedEndpointExtensions.cs
+++ b/BlazorBlog/Feeds/FeedEndpointExtensions.cs
@@ -1,0 +1,77 @@
+namespace BlazorBlog.Feeds
+{
+    using BlazorBlog.Application.Contracts;
+    using BlazorBlog.Infrastructure.Utilities;
+    using BlazorBlog.Utilities;
+    using Ganss.Xss;
+    using Microsoft.Extensions.Caching.Memory;
+    using Microsoft.Extensions.Options;
+
+    public static class FeedEndpointExtensions
+    {
+        public static IEndpointRouteBuilder MapFeedEndpoint(this IEndpointRouteBuilder endpoints)
+        {
+            endpoints.MapGet(
+                    "/feed",
+                    async (
+                        HttpContext context,
+                        IBlogPostService blogPostService,
+                        IHtmlSanitizer htmlSanitizer,
+                        IMemoryCache cache,
+                        IBlogCacheSignal cacheSignal,
+                        IOptions<FeedOptions> options,
+                        CancellationToken cancellationToken) =>
+                    {
+                        var feedOptions = Normalize(options.Value);
+                        var baseUri = GetBaseUri(context.Request);
+                        var feedUri = new Uri(baseUri, "feed");
+                        var cacheKey = BuildCacheKey(baseUri, feedOptions.ItemCount, cacheSignal.Version);
+
+                        var xml = await cache.GetOrCreateAsync(
+                            cacheKey,
+                            async entry =>
+                            {
+                                entry.AbsoluteExpirationRelativeToNow = TimeSpan.FromMinutes(feedOptions.CacheMinutes);
+
+                                var posts = await blogPostService.GetRecentBlogPostsAsync(
+                                    feedOptions.ItemCount,
+                                    cancellationToken: cancellationToken);
+
+                                return RssFeedDocument.Create(
+                                    posts,
+                                    baseUri,
+                                    feedUri,
+                                    feedOptions,
+                                    summary => htmlSanitizer.Sanitize(summary),
+                                    content => BlogContentRenderer.RenderSafeHtml(content, htmlSanitizer));
+                            });
+
+                        return Results.Content(xml ?? string.Empty, "application/rss+xml; charset=utf-8");
+                    })
+                .WithName("Feed")
+                .WithTags("SEO");
+
+            return endpoints;
+        }
+
+        public static string BuildCacheKey(Uri baseUri, int itemCount, long signalVersion)
+            => $"feed:rss:{baseUri.AbsoluteUri}:{itemCount}:{signalVersion}";
+
+        public static FeedOptions Normalize(FeedOptions options)
+            => new()
+            {
+                Title = string.IsNullOrWhiteSpace(options.Title) ? "Blazor Blog" : options.Title.Trim(),
+                Description = string.IsNullOrWhiteSpace(options.Description)
+                    ? "Latest published posts from Blazor Blog."
+                    : options.Description.Trim(),
+                ItemCount = Math.Clamp(options.ItemCount, 1, 100),
+                CacheMinutes = Math.Clamp(options.CacheMinutes, 1, 1440)
+            };
+
+        private static Uri GetBaseUri(HttpRequest request)
+        {
+            var pathBase = request.PathBase.HasValue ? request.PathBase.Value : string.Empty;
+            return new Uri($"{request.Scheme}://{request.Host}{pathBase}/");
+        }
+    }
+}

--- a/BlazorBlog/Feeds/FeedOptions.cs
+++ b/BlazorBlog/Feeds/FeedOptions.cs
@@ -1,0 +1,15 @@
+namespace BlazorBlog.Feeds
+{
+    public sealed class FeedOptions
+    {
+        public const string SectionName = "Feed";
+
+        public string Title { get; set; } = "Blazor Blog";
+
+        public string Description { get; set; } = "Latest published posts from Blazor Blog.";
+
+        public int ItemCount { get; set; } = 20;
+
+        public int CacheMinutes { get; set; } = 10;
+    }
+}

--- a/BlazorBlog/Feeds/RssFeedDocument.cs
+++ b/BlazorBlog/Feeds/RssFeedDocument.cs
@@ -1,0 +1,67 @@
+namespace BlazorBlog.Feeds
+{
+    using System.Globalization;
+    using System.Xml.Linq;
+    using BlazorBlog.Application.Models;
+
+    public static class RssFeedDocument
+    {
+        private static readonly XNamespace ContentNamespace = "http://purl.org/rss/1.0/modules/content/";
+
+        public static string Create(
+            IEnumerable<BlogPostVm> posts,
+            Uri baseUri,
+            Uri feedUri,
+            FeedOptions options,
+            Func<string, string> sanitizeSummary,
+            Func<string, string> renderSafeContent)
+        {
+            var channel = new XElement(
+                "channel",
+                new XElement("title", options.Title),
+                new XElement("link", baseUri.AbsoluteUri),
+                new XElement("description", options.Description),
+                new XElement("language", "en"),
+                new XElement("lastBuildDate", FormatRssDate(DateTime.UtcNow)));
+
+            foreach (var post in posts)
+            {
+                var postUri = new Uri(baseUri, $"posts/{Uri.EscapeDataString(post.Slug)}");
+                var publishedAt = (post.PublishedAt ?? DateTime.UtcNow).ToUniversalTime();
+                var safeSummary = sanitizeSummary(post.Introduction ?? string.Empty);
+                var safeContent = renderSafeContent(post.Content ?? string.Empty);
+
+                channel.Add(
+                    new XElement(
+                        "item",
+                        new XElement("title", post.Title),
+                        new XElement("link", postUri.AbsoluteUri),
+                        new XElement("guid", new XAttribute("isPermaLink", "true"), postUri.AbsoluteUri),
+                        new XElement("pubDate", FormatRssDate(publishedAt)),
+                        new XElement("description", new XCData(safeSummary)),
+                        new XElement(ContentNamespace + "encoded", new XCData(safeContent))));
+            }
+
+            var document = new XDocument(
+                new XDeclaration("1.0", "utf-8", null),
+                new XElement(
+                    "rss",
+                    new XAttribute("version", "2.0"),
+                    new XAttribute(XNamespace.Xmlns + "content", ContentNamespace),
+                    new XAttribute(XNamespace.Xmlns + "atom", "http://www.w3.org/2005/Atom"),
+                    channel));
+
+            channel.AddFirst(
+                new XElement(
+                    XName.Get("link", "http://www.w3.org/2005/Atom"),
+                    new XAttribute("href", feedUri.AbsoluteUri),
+                    new XAttribute("rel", "self"),
+                    new XAttribute("type", "application/rss+xml")));
+
+            return document.ToString(SaveOptions.DisableFormatting);
+        }
+
+        private static string FormatRssDate(DateTime value)
+            => value.ToUniversalTime().ToString("R", CultureInfo.InvariantCulture);
+    }
+}

--- a/BlazorBlog/Program.cs
+++ b/BlazorBlog/Program.cs
@@ -3,6 +3,7 @@ namespace BlazorBlog
     using System.Net;
     using System.Text.Json;
 
+    using BlazorBlog.Feeds;
     using Components.Account;
     using BlazorBlog.Health;
     using BlazorBlog.Infrastructure;
@@ -68,6 +69,7 @@ namespace BlazorBlog
             builder.Services.AddHealthChecks()
                 .AddCheck<DatabaseHealthCheck>("database", tags: ["ready"])
                 .AddCheck<DiskSpaceHealthCheck>("disk", tags: ["ready"]);
+            builder.Services.Configure<FeedOptions>(builder.Configuration.GetSection(FeedOptions.SectionName));
 
             ValidateStartupConfiguration(builder);
 
@@ -123,6 +125,7 @@ namespace BlazorBlog
                 .AddInteractiveServerRenderMode();
 
             app.MapAdditionalIdentityEndpoints();
+            app.MapFeedEndpoint();
 
             app.MapGet("/health", (ILogger<Program> logger) =>
                 {

--- a/BlazorBlog/appsettings.json
+++ b/BlazorBlog/appsettings.json
@@ -31,6 +31,12 @@
       }
     ]
   },
+  "Feed": {
+    "Title": "Blazor Blog",
+    "Description": "Latest published posts from Blazor Blog.",
+    "ItemCount": 20,
+    "CacheMinutes": 10
+  },
   "AdminUser": {
     "Name": "Admin",
     "Email": "admin@bblog.com",


### PR DESCRIPTION
Add RSS feed endpoint with config and tests

Introduced a new RSS feed feature at /feed, including FeedOptions for configuration, FeedEndpointExtensions for endpoint mapping and cache key logic, and RssFeedDocument for generating valid RSS 2.0 XML. Registered feed options and endpoint in Program.cs, updated appsettings.json, and added unit tests for feed logic and output.