### PR TITLE
Add SEO endpoints for sitemap.xml and robots.txt

### DIFF
--- a/BlazorBlog.Application/Contracts/IBlogPostRepository.cs
+++ b/BlazorBlog.Application/Contracts/IBlogPostRepository.cs
@@ -22,5 +22,7 @@ namespace BlazorBlog.Application.Contracts
         Task<BlogPostVm[]> GetPopularBlogPostsByTagAsync(string tagSlug, int count, CancellationToken cancellationToken = default);
 
         Task<BlogPostVm[]> GetBlogPostsByTagAsync(string tagSlug, int pageIndex, int pageSize, CancellationToken cancellationToken = default);
+
+        Task<SitemapPostVm[]> GetSitemapPostsAsync(CancellationToken cancellationToken = default);
     }
 }

--- a/BlazorBlog.Application/Contracts/IBlogPostService.cs
+++ b/BlazorBlog.Application/Contracts/IBlogPostService.cs
@@ -21,5 +21,7 @@ namespace BlazorBlog.Application.Contracts
         Task<BlogPostVm[]> GetPopularBlogPostsByTagAsync(string tagSlug, int count, CancellationToken cancellationToken = default);
 
         Task<BlogPostVm[]> GetBlogPostsByTagAsync(string tagSlug, int pageIndex, int pageSize, CancellationToken cancellationToken = default);
+
+        Task<SitemapPostVm[]> GetSitemapPostsAsync(CancellationToken cancellationToken = default);
     }
 }

--- a/BlazorBlog.Application/Models/SitemapPostVm.cs
+++ b/BlazorBlog.Application/Models/SitemapPostVm.cs
@@ -1,0 +1,11 @@
+namespace BlazorBlog.Application.Models
+{
+    public sealed class SitemapPostVm
+    {
+        public string Slug { get; set; } = string.Empty;
+
+        public string CategorySlug { get; set; } = string.Empty;
+
+        public DateTime LastModifiedUtc { get; set; }
+    }
+}

--- a/BlazorBlog.Infrastructure/BlogPostService.cs
+++ b/BlazorBlog.Infrastructure/BlogPostService.cs
@@ -58,5 +58,8 @@
 
         public Task<BlogPostVm[]> GetBlogPostsByTagAsync(string tagSlug, int pageIndex, int pageSize, CancellationToken cancellationToken = default)
             => _blogPostRepository.GetBlogPostsByTagAsync(tagSlug, pageIndex, pageSize, cancellationToken);
+
+        public Task<SitemapPostVm[]> GetSitemapPostsAsync(CancellationToken cancellationToken = default)
+            => CacheGetOrCreateAsync($"sitemap:posts:{_signal.Version}", () => _blogPostRepository.GetSitemapPostsAsync(cancellationToken));
     }
 }

--- a/BlazorBlog.Infrastructure/Persistence/Repositories/BlogPostRepository.cs
+++ b/BlazorBlog.Infrastructure/Persistence/Repositories/BlogPostRepository.cs
@@ -370,6 +370,32 @@ namespace BlazorBlog.Infrastructure.Persistence.Repositories
             return posts.Select(Map).ToArray();
         }
 
+        public async Task<SitemapPostVm[]> GetSitemapPostsAsync(CancellationToken cancellationToken = default)
+        {
+            await using var context = await _contextFactory.CreateDbContextAsync(cancellationToken);
+
+            var posts = await context.BlogPosts
+                .AsNoTracking()
+                .Where(p => p.IsPublished && !p.IsDeleted && p.Slug != string.Empty)
+                .OrderByDescending(p => p.PublishedAt ?? p.CreatedAt)
+                .Select(p => new
+                {
+                    p.Slug,
+                    CategorySlug = p.Category.Slug,
+                    LastModified = p.PublishedAt ?? p.CreatedAt
+                })
+                .ToArrayAsync(cancellationToken);
+
+            return posts
+                .Select(p => new SitemapPostVm
+                {
+                    Slug = p.Slug,
+                    CategorySlug = p.CategorySlug,
+                    LastModifiedUtc = DateTime.SpecifyKind(p.LastModified, DateTimeKind.Utc).ToUniversalTime()
+                })
+                .ToArray();
+        }
+
         private static bool TryReadRowVersion(byte[]? rowVersion, out uint xmin)
         {
             xmin = default;

--- a/BlazorBlog.Tests/Fakes/FakeBlogPostService.cs
+++ b/BlazorBlog.Tests/Fakes/FakeBlogPostService.cs
@@ -28,5 +28,8 @@ namespace BlazorBlog.Tests.Fakes
 
         public Task<BlogPostVm[]> GetBlogPostsByTagAsync(string tagSlug, int pageIndex, int pageSize, CancellationToken cancellationToken = default)
             => Task.FromResult(Array.Empty<BlogPostVm>());
+
+        public Task<SitemapPostVm[]> GetSitemapPostsAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult(Array.Empty<SitemapPostVm>());
     }
 }

--- a/BlazorBlog.Tests/Seo/RobotsTextDocumentTests.cs
+++ b/BlazorBlog.Tests/Seo/RobotsTextDocumentTests.cs
@@ -1,0 +1,19 @@
+namespace BlazorBlog.Tests.Seo
+{
+    using System;
+    using BlazorBlog.Seo;
+    using Xunit;
+
+    public class RobotsTextDocumentTests
+    {
+        [Fact]
+        public void Create_IncludesSitemapLink()
+        {
+            var robots = RobotsTextDocument.Create(new Uri("https://example.com/blog/"));
+
+            Assert.Contains("User-agent: *", robots);
+            Assert.Contains("Allow: /", robots);
+            Assert.Contains("Sitemap: https://example.com/blog/sitemap.xml", robots);
+        }
+    }
+}

--- a/BlazorBlog.Tests/Seo/SeoEndpointExtensionsTests.cs
+++ b/BlazorBlog.Tests/Seo/SeoEndpointExtensionsTests.cs
@@ -1,0 +1,31 @@
+namespace BlazorBlog.Tests.Seo
+{
+    using System;
+    using BlazorBlog.Seo;
+    using Xunit;
+
+    public class SeoEndpointExtensionsTests
+    {
+        [Fact]
+        public void BuildSitemapCacheKey_ChangesWhenSignalVersionChanges()
+        {
+            var baseUri = new Uri("https://example.com/");
+
+            var first = SeoEndpointExtensions.BuildSitemapCacheKey(baseUri, signalVersion: 1);
+            var second = SeoEndpointExtensions.BuildSitemapCacheKey(baseUri, signalVersion: 2);
+
+            Assert.NotEqual(first, second);
+        }
+
+        [Theory]
+        [InlineData(0, 1)]
+        [InlineData(15, 15)]
+        [InlineData(2000, 1440)]
+        public void Normalize_ClampsCacheMinutes(int configured, int expected)
+        {
+            var options = SeoEndpointExtensions.Normalize(new SitemapOptions { CacheMinutes = configured });
+
+            Assert.Equal(expected, options.CacheMinutes);
+        }
+    }
+}

--- a/BlazorBlog.Tests/Seo/SitemapDocumentTests.cs
+++ b/BlazorBlog.Tests/Seo/SitemapDocumentTests.cs
@@ -1,0 +1,79 @@
+namespace BlazorBlog.Tests.Seo
+{
+    using System;
+    using System.Linq;
+    using System.Xml.Linq;
+    using BlazorBlog.Application.Models;
+    using BlazorBlog.Seo;
+    using Xunit;
+
+    public class SitemapDocumentTests
+    {
+        [Fact]
+        public void Create_IncludesKeyPagesCategoriesAndPublishedPosts()
+        {
+            var posts = new[]
+            {
+                new SitemapPostVm
+                {
+                    Slug = "hello-world",
+                    CategorySlug = "blazor",
+                    LastModifiedUtc = new DateTime(2026, 5, 24, 10, 30, 0, DateTimeKind.Utc)
+                },
+                new SitemapPostVm
+                {
+                    Slug = "second-post",
+                    CategorySlug = "csharp",
+                    LastModifiedUtc = new DateTime(2026, 5, 20, 8, 0, 0, DateTimeKind.Utc)
+                }
+            };
+
+            var xml = SitemapDocument.Create(
+                new Uri("https://example.com/blog/"),
+                posts,
+                new DateTime(2026, 5, 25, 12, 0, 0, DateTimeKind.Utc));
+
+            var document = XDocument.Parse(xml);
+            XNamespace ns = "http://www.sitemaps.org/schemas/sitemap/0.9";
+            var urls = document.Root!.Elements(ns + "url").ToArray();
+            var locations = urls.Select(url => url.Element(ns + "loc")?.Value).ToArray();
+
+            Assert.Equal("urlset", document.Root.Name.LocalName);
+            Assert.Contains("https://example.com/blog/", locations);
+            Assert.Contains("https://example.com/blog/posts", locations);
+            Assert.Contains("https://example.com/blog/blazor-posts", locations);
+            Assert.Contains("https://example.com/blog/csharp-posts", locations);
+            Assert.Contains("https://example.com/blog/posts/hello-world", locations);
+            Assert.Contains("https://example.com/blog/posts/second-post", locations);
+
+            var firstPost = urls.Single(url => url.Element(ns + "loc")?.Value == "https://example.com/blog/posts/hello-world");
+            Assert.Equal("2026-05-24T10:30:00Z", firstPost.Element(ns + "lastmod")?.Value);
+            Assert.Equal("monthly", firstPost.Element(ns + "changefreq")?.Value);
+            Assert.Equal("0.8", firstPost.Element(ns + "priority")?.Value);
+        }
+
+        [Fact]
+        public void Create_SkipsPostsWithoutSlugs()
+        {
+            var posts = new[]
+            {
+                new SitemapPostVm
+                {
+                    Slug = "",
+                    CategorySlug = "drafts",
+                    LastModifiedUtc = DateTime.UtcNow
+                }
+            };
+
+            var xml = SitemapDocument.Create(new Uri("https://example.com/"), posts, DateTime.UtcNow);
+            var document = XDocument.Parse(xml);
+            XNamespace ns = "http://www.sitemaps.org/schemas/sitemap/0.9";
+            var locations = document.Root!.Elements(ns + "url")
+                .Select(url => url.Element(ns + "loc")?.Value)
+                .ToArray();
+
+            Assert.DoesNotContain("https://example.com/posts/", locations);
+            Assert.DoesNotContain("https://example.com/drafts-posts", locations);
+        }
+    }
+}

--- a/BlazorBlog/Program.cs
+++ b/BlazorBlog/Program.cs
@@ -4,6 +4,7 @@ namespace BlazorBlog
     using System.Text.Json;
 
     using BlazorBlog.Feeds;
+    using BlazorBlog.Seo;
     using Components.Account;
     using BlazorBlog.Health;
     using BlazorBlog.Infrastructure;
@@ -70,6 +71,7 @@ namespace BlazorBlog
                 .AddCheck<DatabaseHealthCheck>("database", tags: ["ready"])
                 .AddCheck<DiskSpaceHealthCheck>("disk", tags: ["ready"]);
             builder.Services.Configure<FeedOptions>(builder.Configuration.GetSection(FeedOptions.SectionName));
+            builder.Services.Configure<SitemapOptions>(builder.Configuration.GetSection(SitemapOptions.SectionName));
 
             ValidateStartupConfiguration(builder);
 
@@ -126,6 +128,7 @@ namespace BlazorBlog
 
             app.MapAdditionalIdentityEndpoints();
             app.MapFeedEndpoint();
+            app.MapSeoEndpoints();
 
             app.MapGet("/health", (ILogger<Program> logger) =>
                 {

--- a/BlazorBlog/Seo/RobotsTextDocument.cs
+++ b/BlazorBlog/Seo/RobotsTextDocument.cs
@@ -1,0 +1,18 @@
+namespace BlazorBlog.Seo
+{
+    public static class RobotsTextDocument
+    {
+        public static string Create(Uri baseUri)
+        {
+            var sitemapUri = new Uri(baseUri, "sitemap.xml");
+
+            return string.Join(
+                "\n",
+                "User-agent: *",
+                "Allow: /",
+                string.Empty,
+                $"Sitemap: {sitemapUri.AbsoluteUri}",
+                string.Empty);
+        }
+    }
+}

--- a/BlazorBlog/Seo/SeoEndpointExtensions.cs
+++ b/BlazorBlog/Seo/SeoEndpointExtensions.cs
@@ -1,0 +1,69 @@
+namespace BlazorBlog.Seo
+{
+    using BlazorBlog.Application.Contracts;
+    using BlazorBlog.Infrastructure.Utilities;
+    using Microsoft.Extensions.Caching.Memory;
+    using Microsoft.Extensions.Options;
+
+    public static class SeoEndpointExtensions
+    {
+        public static IEndpointRouteBuilder MapSeoEndpoints(this IEndpointRouteBuilder endpoints)
+        {
+            endpoints.MapGet(
+                    "/sitemap.xml",
+                    async (
+                        HttpContext context,
+                        IBlogPostService blogPostService,
+                        IMemoryCache cache,
+                        IBlogCacheSignal cacheSignal,
+                        IOptions<SitemapOptions> options,
+                        CancellationToken cancellationToken) =>
+                    {
+                        var sitemapOptions = Normalize(options.Value);
+                        var baseUri = GetBaseUri(context.Request);
+                        var cacheKey = BuildSitemapCacheKey(baseUri, cacheSignal.Version);
+
+                        var xml = await cache.GetOrCreateAsync(
+                            cacheKey,
+                            async entry =>
+                            {
+                                entry.AbsoluteExpirationRelativeToNow = TimeSpan.FromMinutes(sitemapOptions.CacheMinutes);
+
+                                var posts = await blogPostService.GetSitemapPostsAsync(cancellationToken);
+                                return SitemapDocument.Create(baseUri, posts, DateTime.UtcNow);
+                            });
+
+                        return Results.Content(xml ?? string.Empty, "application/xml; charset=utf-8");
+                    })
+                .WithName("Sitemap")
+                .WithTags("SEO");
+
+            endpoints.MapGet(
+                    "/robots.txt",
+                    (HttpContext context) =>
+                    {
+                        var baseUri = GetBaseUri(context.Request);
+                        return Results.Text(RobotsTextDocument.Create(baseUri), "text/plain; charset=utf-8");
+                    })
+                .WithName("RobotsTxt")
+                .WithTags("SEO");
+
+            return endpoints;
+        }
+
+        public static string BuildSitemapCacheKey(Uri baseUri, long signalVersion)
+            => $"sitemap:xml:{baseUri.AbsoluteUri}:{signalVersion}";
+
+        public static SitemapOptions Normalize(SitemapOptions options)
+            => new()
+            {
+                CacheMinutes = Math.Clamp(options.CacheMinutes, 1, 1440)
+            };
+
+        private static Uri GetBaseUri(HttpRequest request)
+        {
+            var pathBase = request.PathBase.HasValue ? request.PathBase.Value : string.Empty;
+            return new Uri($"{request.Scheme}://{request.Host}{pathBase}/");
+        }
+    }
+}

--- a/BlazorBlog/Seo/SitemapDocument.cs
+++ b/BlazorBlog/Seo/SitemapDocument.cs
@@ -1,0 +1,85 @@
+namespace BlazorBlog.Seo
+{
+    using System.Globalization;
+    using System.Xml.Linq;
+    using BlazorBlog.Application.Models;
+
+    public static class SitemapDocument
+    {
+        private static readonly XNamespace SitemapNamespace = "http://www.sitemaps.org/schemas/sitemap/0.9";
+
+        public static string Create(Uri baseUri, IEnumerable<SitemapPostVm> posts, DateTime generatedAtUtc)
+        {
+            var normalizedPosts = posts
+                .Where(post => !string.IsNullOrWhiteSpace(post.Slug))
+                .Select(post => new SitemapPostVm
+                {
+                    Slug = post.Slug.Trim('/'),
+                    CategorySlug = post.CategorySlug.Trim('/'),
+                    LastModifiedUtc = EnsureUtc(post.LastModifiedUtc)
+                })
+                .ToArray();
+
+            var latestPostChange = normalizedPosts.Length > 0
+                ? normalizedPosts.Max(post => post.LastModifiedUtc)
+                : EnsureUtc(generatedAtUtc);
+
+            var urls = BuildKeyPages(latestPostChange)
+                .Concat(BuildCategoryPages(normalizedPosts))
+                .Concat(BuildPostPages(normalizedPosts))
+                .Select(url => new XElement(
+                    SitemapNamespace + "url",
+                    new XElement(SitemapNamespace + "loc", BuildAbsoluteUrl(baseUri, url.Location)),
+                    new XElement(SitemapNamespace + "lastmod", FormatLastModified(url.LastModifiedUtc)),
+                    new XElement(SitemapNamespace + "changefreq", url.ChangeFrequency),
+                    new XElement(SitemapNamespace + "priority", url.Priority)));
+
+            var document = new XDocument(
+                new XDeclaration("1.0", "utf-8", null),
+                new XElement(SitemapNamespace + "urlset", urls));
+
+            return document.ToString(SaveOptions.DisableFormatting);
+        }
+
+        private static IEnumerable<SitemapUrl> BuildKeyPages(DateTime lastModifiedUtc)
+        {
+            yield return new SitemapUrl(string.Empty, lastModifiedUtc, "daily", "1.0");
+            yield return new SitemapUrl("posts", lastModifiedUtc, "daily", "0.9");
+            yield return new SitemapUrl("privacy", lastModifiedUtc, "yearly", "0.3");
+            yield return new SitemapUrl("terms", lastModifiedUtc, "yearly", "0.3");
+        }
+
+        private static IEnumerable<SitemapUrl> BuildCategoryPages(IEnumerable<SitemapPostVm> posts)
+            => posts
+                .Where(post => !string.IsNullOrWhiteSpace(post.CategorySlug))
+                .GroupBy(post => post.CategorySlug, StringComparer.OrdinalIgnoreCase)
+                .OrderBy(group => group.Key, StringComparer.OrdinalIgnoreCase)
+                .Select(group => new SitemapUrl(
+                    $"{group.Key}-posts",
+                    group.Max(post => post.LastModifiedUtc),
+                    "weekly",
+                    "0.7"));
+
+        private static IEnumerable<SitemapUrl> BuildPostPages(IEnumerable<SitemapPostVm> posts)
+            => posts
+                .OrderByDescending(post => post.LastModifiedUtc)
+                .ThenBy(post => post.Slug, StringComparer.OrdinalIgnoreCase)
+                .Select(post => new SitemapUrl($"posts/{post.Slug}", post.LastModifiedUtc, "monthly", "0.8"));
+
+        private static string BuildAbsoluteUrl(Uri baseUri, string relativePath)
+            => string.IsNullOrWhiteSpace(relativePath)
+                ? baseUri.AbsoluteUri
+                : new Uri(baseUri, relativePath).AbsoluteUri;
+
+        private static string FormatLastModified(DateTime value)
+            => EnsureUtc(value).ToString("yyyy-MM-dd'T'HH:mm:ss'Z'", CultureInfo.InvariantCulture);
+
+        private static DateTime EnsureUtc(DateTime value)
+            => value.Kind switch
+            {
+                DateTimeKind.Utc => value,
+                DateTimeKind.Local => value.ToUniversalTime(),
+                _ => DateTime.SpecifyKind(value, DateTimeKind.Utc)
+            };
+    }
+}

--- a/BlazorBlog/Seo/SitemapOptions.cs
+++ b/BlazorBlog/Seo/SitemapOptions.cs
@@ -1,0 +1,9 @@
+namespace BlazorBlog.Seo
+{
+    public sealed class SitemapOptions
+    {
+        public const string SectionName = "Sitemap";
+
+        public int CacheMinutes { get; set; } = 10;
+    }
+}

--- a/BlazorBlog/Seo/SitemapUrl.cs
+++ b/BlazorBlog/Seo/SitemapUrl.cs
@@ -1,0 +1,4 @@
+namespace BlazorBlog.Seo
+{
+    public sealed record SitemapUrl(string Location, DateTime LastModifiedUtc, string ChangeFrequency, string Priority);
+}

--- a/BlazorBlog/appsettings.json
+++ b/BlazorBlog/appsettings.json
@@ -37,6 +37,9 @@
     "ItemCount": 20,
     "CacheMinutes": 10
   },
+  "Sitemap": {
+    "CacheMinutes": 10
+  },
   "AdminUser": {
     "Name": "Admin",
     "Email": "admin@bblog.com",


### PR DESCRIPTION
Add SEO endpoints for sitemap.xml and robots.txt

Implement sitemap and robots.txt endpoints with caching and configuration. Add SitemapPostVm, SitemapUrl, and SitemapDocument for sitemap generation. Update repository and service layers to support sitemap data. Register endpoints in Program.cs and add related tests. Update appsettings.json with Sitemap options.